### PR TITLE
feat: test specs improvements

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,7 @@
 ---
 title: Testing
-description: Learn how to test your features and segments in Featurevisor with YAML specs
+description: Learn how to test your features and segments in Featurevisor with declarative specs
+ogImage: /img/og/docs-testing.png
 ---
 
 Features and segments can grow into complex configuration very fast, and it's important that you have the confidence they are working as expected. {% .lead %}
@@ -43,34 +44,32 @@ We can create a new test spec for it in `tests` directory:
 
 ```yml
 # tests/foo.feature.yml
-tests:
-  - tag: all
+feature: foo # your feature key
+assertions:
+
+  # asserting evaluated variation
+  # against bucketed value and context
+  - description: Testing variation at 40% in NL
     environment: production
-    features:
-      - key: foo # your feature key
-        assertions:
+    at: 40
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          # asserting evaluated variation
-          # against bucketed value and context
-          - description: Testing variation at 40% in NL
-            at: 40
-            context:
-              country: nl
-            expectedToBeEnabled: true
+    # if testing variations
+    expectedVariation: control
 
-            # if testing variations
-            expectedVariation: control
+  # asserting evaluated variables
+  - description: Testing variables at 90% in NL
+    environment: production
+    at: 90
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          # asserting evaluated variables
-          - description: Testing variables at 90% in NL
-            at: 90
-            context:
-              country: nl
-            expectedToBeEnabled: true
-
-            # if testing variables
-            expectedVariables:
-              someKey: someValue
+    # if testing variables
+    expectedVariables:
+      someKey: someValue
 ```
 
 The `at` property is the bucketed value (in percentage form ranging from 0 to 100) that assertions will be run against.
@@ -96,24 +95,22 @@ We can create a new test spec in `tests` directory:
 
 ```yml
 # tests/netherlands.segment.yml
-tests:
-  - segments:
-      - key: netherlands # your segment key
-        assertions:
-          - description: Testing segment in NL
-            context:
-              country: nl
-            expectedToMatch: true
+segment: netherlands # your segment key
+assertions:
+  - description: Testing segment in NL
+    context:
+      country: nl
+    expectedToMatch: true
 
-          - description: Testing segment in DE
-            context:
-              country: de
-            expectedToMatch: false
+  - description: Testing segment in DE
+    context:
+      country: de
+    expectedToMatch: false
 ```
 
 ## Running tests
 
-After [building datafiles](/docs/building-datafiles), use the Featurevisor CLI to run your tests:
+Use the Featurevisor CLI to run your tests:
 
 ```
 $ featurevisor test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,9 +6,9 @@ ogImage: /img/og/docs-testing.png
 
 Features and segments can grow into complex configuration very fast, and it's important that you have the confidence they are working as expected. {% .lead %}
 
-## Testing features
+We can write test specs in the same expressive way as we defined our features to test them in great detail.
 
-We can write test specs in the same expressive way as we defined our features to test your them in great detail.
+## Testing features
 
 Assuming we already have a `foo` feature in `features/foo.yml`:
 
@@ -72,13 +72,13 @@ assertions:
       someKey: someValue
 ```
 
-The `at` property is the bucketed value (in percentage form ranging from 0 to 100) that assertions will be run against.
+The `at` property is the bucketed value (in percentage form ranging from 0 to 100) that assertions will be run against. Read more in [Bucketing](/docs/bucketing).
 
-Read more in [Bucketing](/docs/bucketing).
+File names of test specs are not important, but we recommend using the same name as the feature key.
 
 ## Testing segments
 
-Similar to features, you can write test specs to test your segments as well.
+Similar to features, we can write test specs to test our segments as well.
 
 Assuming we already have a `netherlands` segment:
 

--- a/examples/example-1/tests/bar.spec.yml
+++ b/examples/example-1/tests/bar.spec.yml
@@ -1,41 +1,40 @@
-tests:
-  - tag: all
+feature: bar
+assertions:
+  - at: 15 # 30 * 0.5
     environment: staging
-    features:
-      - key: bar
-        assertions:
-          - at: 15 # 30 * 0.5
-            context:
-              country: us
-            expectedToBeEnabled: true
-            expectedVariation: control
-            expectedVariables:
-              color: red
-              hero:
-                title: Hero Title
-                subtitle: Hero Subtitle
-                alignment: center
+    context:
+      country: us
+    expectedToBeEnabled: true
+    expectedVariation: control
+    expectedVariables:
+      color: red
+      hero:
+        title: Hero Title
+        subtitle: Hero Subtitle
+        alignment: center
 
-          - at: 20 # 40 * 0.5
-            context:
-              country: us
-            expectedToBeEnabled: true
-            expectedVariation: b
-            expectedVariables:
-              color: red
-              hero:
-                title: Hero Title for B
-                subtitle: Hero Subtitle for B
-                alignment: center for B
+  - at: 20 # 40 * 0.5
+    environment: staging
+    context:
+      country: us
+    expectedToBeEnabled: true
+    expectedVariation: b
+    expectedVariables:
+      color: red
+      hero:
+        title: Hero Title for B
+        subtitle: Hero Subtitle for B
+        alignment: center for B
 
-          - at: 20 # 40 * 0.5
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: b
-            expectedVariables:
-              color: red
-              hero:
-                title: Hero Title for B in DE or CH
-                subtitle: Hero Subtitle for B in DE of CH
-                alignment: center for B in DE or CH
+  - at: 20 # 40 * 0.5
+    environment: staging
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: b
+    expectedVariables:
+      color: red
+      hero:
+        title: Hero Title for B in DE or CH
+        subtitle: Hero Subtitle for B in DE of CH
+        alignment: center for B in DE or CH

--- a/examples/example-1/tests/baz.spec.yml
+++ b/examples/example-1/tests/baz.spec.yml
@@ -1,23 +1,22 @@
-tests:
-  - tag: all
+feature: baz
+assertions:
+  - at: 10
+    description: "At 10%, the feature should be enabled"
     environment: production
-    features:
-      - key: baz
-        assertions:
-          - at: 10
-            description: "At 10%, the feature should be enabled"
-            context:
-              country: nl
-            expectedToBeEnabled: true
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          - at: 70
-            description: "At 70%, the feature should be enabled"
-            context:
-              country: nl
-            expectedToBeEnabled: true
+  - at: 70
+    description: "At 70%, the feature should be enabled"
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          - at: 90
-            description: "At 90%, the feature should be disabled"
-            context:
-              country: nl
-            expectedToBeEnabled: false
+  - at: 90
+    description: "At 90%, the feature should be disabled"
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: false

--- a/examples/example-1/tests/discount.spec.yml
+++ b/examples/example-1/tests/discount.spec.yml
@@ -1,23 +1,22 @@
-tests:
-  - tag: all
+feature: discount
+assertions:
+  - at: 10
+    description: "At 10%, the feature should be disabled on 1st January 2023"
     environment: production
-    features:
-      - key: discount
-        assertions:
-          - at: 10
-            description: "At 10%, the feature should be disabled on 1st January 2023"
-            context:
-              date: 2023-01-01T00:00:00Z
-            expectedToBeEnabled: false
+    context:
+      date: 2023-01-01T00:00:00Z
+    expectedToBeEnabled: false
 
-          - at: 70
-            description: "At 70%, the feature should be disabled on 25th December 2023"
-            context:
-              date: 2023-12-25T00:00:00Z
-            expectedToBeEnabled: false
+  - at: 70
+    description: "At 70%, the feature should be disabled on 25th December 2023"
+    environment: production
+    context:
+      date: 2023-12-25T00:00:00Z
+    expectedToBeEnabled: false
 
-          - at: 90
-            description: "At 90%, the feature should be enabled on 25th November 2023"
-            context:
-              date: 2023-11-25T00:00:00Z
-            expectedToBeEnabled: true
+  - at: 90
+    description: "At 90%, the feature should be enabled on 25th November 2023"
+    environment: production
+    context:
+      date: 2023-11-25T00:00:00Z
+    expectedToBeEnabled: true

--- a/examples/example-1/tests/foo.spec.yml
+++ b/examples/example-1/tests/foo.spec.yml
@@ -1,41 +1,42 @@
-tests:
-  - tag: all
+feature: foo
+assertions:
+  - at: 40
     environment: staging
-    features:
-      - key: foo
-        assertions:
-          - at: 40
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: control
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: control
 
-          - at: 60
-            context:
-              country: ch
-            expectedToBeEnabled: true
-            expectedVariation: treatment
+  - at: 60
+    environment: staging
+    context:
+      country: ch
+    expectedToBeEnabled: true
+    expectedVariation: treatment
 
-          - at: 60
-            context:
-              country: us
-            expectedToBeEnabled: true
-            expectedVariation: treatment
+  - at: 60
+    environment: staging
+    context:
+      country: us
+    expectedToBeEnabled: true
+    expectedVariation: treatment
 
-          - at: 60
-            context:
-              country: us
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              bar: bar_here
-              baz: baz_here
+  - at: 60
+    environment: staging
+    context:
+      country: us
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      bar: bar_here
+      baz: baz_here
 
-          - at: 80
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              bar: bar for DE or CH
-              baz: baz_here
+  - at: 80
+    environment: staging
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      bar: bar for DE or CH
+      baz: baz_here

--- a/examples/example-1/tests/germany.spec.yml
+++ b/examples/example-1/tests/germany.spec.yml
@@ -1,16 +1,14 @@
-tests:
-  - segments:
-      - key: germany
-        assertions:
-          - context:
-              country: de
-            expectedToMatch: true
+segment: germany
+assertions:
+  - context:
+      country: de
+    expectedToMatch: true
 
-          - context:
-              country: de
-              someOtherAttribute: someOtherValue
-            expectedToMatch: true
+  - context:
+      country: de
+      someOtherAttribute: someOtherValue
+    expectedToMatch: true
 
-          - context:
-              country: notDe
-            expectedToMatch: false
+  - context:
+      country: notDe
+    expectedToMatch: false

--- a/examples/example-1/tests/qux.spec.yml
+++ b/examples/example-1/tests/qux.spec.yml
@@ -1,65 +1,70 @@
-tests:
-  - tag: all
+feature: qux
+assertions:
+  - at: 66.5 # (33.33 * 0.5) + 50
     environment: production
-    features:
-      - key: qux
-        assertions:
-          - at: 66.5 # (33.33 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: control
-            expectedVariables:
-              fooConfig:
-                foo: bar
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: control
+    expectedVariables:
+      fooConfig:
+        foo: bar
 
-          - at: 66.665 # (33.33 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: control
+  - at: 66.665 # (33.33 * 0.5) + 50
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: control
 
-          - at: 66.67 # (33.34 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: control
+  - at: 66.67 # (33.34 * 0.5) + 50
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: control
 
-          - at: 66.675 # (33.35 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: b
-            expectedVariables:
-              fooConfig:
-                foo: bar b
+  - at: 66.675 # (33.35 * 0.5) + 50
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: b
+    expectedVariables:
+      fooConfig:
+        foo: bar b
 
-          - at: 67 # (42 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: b
+  - at: 67 # (42 * 0.5) + 50
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: b
 
-          - at: 83 # (66 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: b
+  - at: 83 # (66 * 0.5) + 50
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: b
 
-          - at: 83.5 # (67 * 0.5) + 50
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: c
+  - at: 83.5 # (67 * 0.5) + 50
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: c
 
-          - at: 95 # (90 * 0.5) + 50
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: b
+  - at: 95 # (90 * 0.5) + 50
+    environment: production
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: b
 
-          - at: 55 # (10 * 0.5) + 50
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: b
+  - at: 55 # (10 * 0.5) + 50
+    environment: production
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: b

--- a/examples/example-1/tests/redesign.spec.yml
+++ b/examples/example-1/tests/redesign.spec.yml
@@ -1,15 +1,13 @@
-tests:
-  - tag: all
+feature: redesign
+assertions:
+  - at: 40
     environment: production
-    features:
-      - key: redesign
-        assertions:
-          - at: 40
-            context:
-              country: nl
-            expectedToBeEnabled: true
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          - at: 40
-            context:
-              country: de
-            expectedToBeEnabled: false
+  - at: 40
+    environment: production
+    context:
+      country: de
+    expectedToBeEnabled: false

--- a/examples/example-1/tests/sidebar.spec.yml
+++ b/examples/example-1/tests/sidebar.spec.yml
@@ -1,61 +1,64 @@
-tests:
-  - tag: all
+feature: sidebar
+assertions:
+  - at: 5
     environment: production
-    features:
-      - key: sidebar
-        assertions:
-          - at: 5
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: control
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: control
 
-          - at: 90
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: treatment
+  - at: 90
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: treatment
 
-          - at: 90
-            context:
-              country: nl
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              position: right
-              color: red
+  - at: 90
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      position: right
+      color: red
 
-          - at: 90
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              position: right
-              color: yellow
-              title: Sidebar Title for production
+  - at: 90
+    environment: production
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      position: right
+      color: yellow
+      title: Sidebar Title for production
 
-          - at: 90
-            context:
-              country: us
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              sections: ["home", "about", "contact"]
+  - at: 90
+    environment: production
+    context:
+      country: us
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      sections: ["home", "about", "contact"]
 
-          - at: 90
-            context:
-              country: de
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              sections: ["home", "about", "contact", "imprint"]
+  - at: 90
+    environment: production
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      sections: ["home", "about", "contact", "imprint"]
 
-          - at: 70
-            context:
-              country: nl
-              userId: "123"
-            expectedToBeEnabled: true
-            expectedVariation: treatment
-            expectedVariables:
-              sections: ["home", "about", "contact", "bitterballen"]
+  - at: 70
+    environment: production
+    context:
+      country: nl
+      userId: "123"
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      sections: ["home", "about", "contact", "bitterballen"]

--- a/examples/example-json/tests/netherlands.segment.json
+++ b/examples/example-json/tests/netherlands.segment.json
@@ -1,32 +1,24 @@
 {
-  "tests": [
+  "segment": "netherlands",
+  "assertions": [
     {
-      "segments": [
-        {
-          "key": "netherlands",
-          "assertions": [
-            {
-              "context": {
-                "country": "nl"
-              },
-              "expectedToMatch": true
-            },
-            {
-              "context": {
-                "country": "de",
-                "someOtherAttribute": "someOtherValue"
-              },
-              "expectedToMatch": false
-            },
-            {
-              "context": {
-                "country": "notNl"
-              },
-              "expectedToMatch": false
-            }
-          ]
-        }
-      ]
+      "context": {
+        "country": "nl"
+      },
+      "expectedToMatch": true
+    },
+    {
+      "context": {
+        "country": "de",
+        "someOtherAttribute": "someOtherValue"
+      },
+      "expectedToMatch": false
+    },
+    {
+      "context": {
+        "country": "notNl"
+      },
+      "expectedToMatch": false
     }
   ]
 }

--- a/examples/example-json/tests/showCookieBanner.feature.json
+++ b/examples/example-json/tests/showCookieBanner.feature.json
@@ -1,47 +1,41 @@
 {
-  "tests": [
+  "feature": "showCookieBanner",
+  "assertions": [
     {
-      "tag": "all",
+      "at": 10,
+      "description": "At 10%, the feature should be enabled for NL",
       "environment": "production",
-      "features": [
-        {
-          "key": "showCookieBanner",
-          "assertions": [
-            {
-              "at": 10,
-              "description": "At 10%, the feature should be enabled for NL",
-              "context": {
-                "country": "nl"
-              },
-              "expectedToBeEnabled": true
-            },
-            {
-              "at": 70,
-              "description": "At 70%, the feature should be enabled for NL",
-              "context": {
-                "country": "nl"
-              },
-              "expectedToBeEnabled": true
-            },
-            {
-              "at": 90,
-              "description": "At 90%, the feature should be disabled for US",
-              "context": {
-                "country": "us"
-              },
-              "expectedToBeEnabled": false
-            },
-            {
-              "at": 90,
-              "description": "At 90%, the feature should be disabled for Canada",
-              "context": {
-                "country": "ca"
-              },
-              "expectedToBeEnabled": false
-            }
-          ]
-        }
-      ]
+      "context": {
+        "country": "nl"
+      },
+      "expectedToBeEnabled": true
+    },
+    {
+      "at": 70,
+      "description": "At 70%, the feature should be enabled for NL",
+      "environment": "production",
+      "context": {
+        "country": "nl"
+      },
+      "expectedToBeEnabled": true
+    },
+    {
+      "at": 90,
+      "description": "At 90%, the feature should be disabled for US",
+      "environment": "production",
+      "context": {
+        "country": "us"
+      },
+      "expectedToBeEnabled": false
+    },
+    {
+      "at": 90,
+      "description": "At 90%, the feature should be disabled for Canada",
+      "environment": "production",
+      "context": {
+        "country": "ca"
+      },
+      "expectedToBeEnabled": false
     }
   ]
 }

--- a/examples/example-toml/tests/netherlands.segment.toml
+++ b/examples/example-toml/tests/netherlands.segment.toml
@@ -1,22 +1,20 @@
-[[tests]]
-[[tests.segments]]
-key = "netherlands"
+segment = "netherlands"
 
-[[tests.segments.assertions]]
+[[assertions]]
 expectedToMatch = true
 
-[tests.segments.assertions.context]
+[assertions.context]
 country = "nl"
 
-[[tests.segments.assertions]]
+[[assertions]]
 expectedToMatch = false
 
-[tests.segments.assertions.context]
+[assertions.context]
 country = "de"
 someOtherAttribute = "someOtherValue"
 
-[[tests.segments.assertions]]
+[[assertions]]
 expectedToMatch = false
 
-[tests.segments.assertions.context]
+[assertions.context]
 country = "notNl"

--- a/examples/example-toml/tests/showCookieBanner.feature.toml
+++ b/examples/example-toml/tests/showCookieBanner.feature.toml
@@ -4,30 +4,30 @@ feature = "showCookieBanner"
 at = 10
 description = "At 10%, the feature should be enabled for NL"
 environment = "production"
+expectedToBeEnabled = true
 [assertions.context]
 country = "nl"
-expectedToBeEnabled = true
 
 [[assertions]]
 at = 70
 description = "At 70%, the feature should be enabled for NL"
 environment = "production"
+expectedToBeEnabled = true
 [assertions.context]
 country = "nl"
-expectedToBeEnabled = true
 
 [[assertions]]
 at = 90
 description = "At 90%, the feature should be disabled for US"
 environment = "production"
+expectedToBeEnabled = false
 [assertions.context]
 country = "us"
-expectedToBeEnabled = false
 
 [[assertions]]
 at = 90
 description = "At 90%, the feature should be disabled for Canada"
 environment = "production"
+expectedToBeEnabled = false
 [assertions.context]
 country = "ca"
-expectedToBeEnabled = false

--- a/examples/example-toml/tests/showCookieBanner.feature.toml
+++ b/examples/example-toml/tests/showCookieBanner.feature.toml
@@ -1,38 +1,33 @@
-[[tests]]
-environment = "production"
-tag = "all"
+feature = "showCookieBanner"
 
-[[tests.features]]
-key = "showCookieBanner"
-
-[[tests.features.assertions]]
+[[assertions]]
 at = 10
 description = "At 10%, the feature should be enabled for NL"
+environment = "production"
+[assertions.context]
+country = "nl"
 expectedToBeEnabled = true
 
-[tests.features.assertions.context]
-country = "nl"
-
-[[tests.features.assertions]]
+[[assertions]]
 at = 70
 description = "At 70%, the feature should be enabled for NL"
+environment = "production"
+[assertions.context]
+country = "nl"
 expectedToBeEnabled = true
 
-[tests.features.assertions.context]
-country = "nl"
-
-[[tests.features.assertions]]
+[[assertions]]
 at = 90
 description = "At 90%, the feature should be disabled for US"
+environment = "production"
+[assertions.context]
+country = "us"
 expectedToBeEnabled = false
 
-[tests.features.assertions.context]
-country = "us"
-
-[[tests.features.assertions]]
+[[assertions]]
 at = 90
 description = "At 90%, the feature should be disabled for Canada"
-expectedToBeEnabled = false
-
-[tests.features.assertions.context]
+environment = "production"
+[assertions.context]
 country = "ca"
+expectedToBeEnabled = false

--- a/examples/example-yml/tests/netherlands.segment.yml
+++ b/examples/example-yml/tests/netherlands.segment.yml
@@ -1,16 +1,14 @@
-tests:
-  - segments:
-      - key: netherlands
-        assertions:
-          - context:
-              country: nl
-            expectedToMatch: true
+segment: netherlands
+assertions:
+  - context:
+      country: nl
+    expectedToMatch: true
 
-          - context:
-              country: de
-              someOtherAttribute: someOtherValue
-            expectedToMatch: false
+  - context:
+      country: de
+      someOtherAttribute: someOtherValue
+    expectedToMatch: false
 
-          - context:
-              country: notNl
-            expectedToMatch: false
+  - context:
+      country: notNl
+    expectedToMatch: false

--- a/examples/example-yml/tests/showCookieBanner.feature.yml
+++ b/examples/example-yml/tests/showCookieBanner.feature.yml
@@ -1,29 +1,29 @@
-tests:
-  - tag: all
+feature: showCookieBanner
+assertions:
+  - at: 10
+    description: "At 10%, the feature should be enabled for NL"
     environment: production
-    features:
-      - key: showCookieBanner
-        assertions:
-          - at: 10
-            description: "At 10%, the feature should be enabled for NL"
-            context:
-              country: nl
-            expectedToBeEnabled: true
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          - at: 70
-            description: "At 70%, the feature should be enabled for NL"
-            context:
-              country: nl
-            expectedToBeEnabled: true
+  - at: 70
+    description: "At 70%, the feature should be enabled for NL"
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
 
-          - at: 90
-            description: "At 90%, the feature should be disabled for US"
-            context:
-              country: us
-            expectedToBeEnabled: false
+  - at: 90
+    description: "At 90%, the feature should be disabled for US"
+    environment: production
+    context:
+      country: us
+    expectedToBeEnabled: false
 
-          - at: 90
-            description: "At 90%, the feature should be disabled for Canada"
-            context:
-              country: ca
-            expectedToBeEnabled: false
+  - at: 90
+    description: "At 90%, the feature should be disabled for Canada"
+    environment: production
+    context:
+      country: ca
+    expectedToBeEnabled: false

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -33,7 +33,8 @@ export interface BuildOptions {
   schemaVersion: string;
   revision: string;
   environment: string;
-  tag: string;
+  tag?: string;
+  features?: FeatureKey[];
 }
 
 export function getDatafilePath(
@@ -140,7 +141,11 @@ export function buildDatafile(
         continue;
       }
 
-      if (parsedFeature.tags.indexOf(options.tag) === -1) {
+      if (options.tag && parsedFeature.tags.indexOf(options.tag) === -1) {
+        continue;
+      }
+
+      if (options.features && options.features.indexOf(featureKey) === -1) {
         continue;
       }
 

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -124,9 +124,7 @@ export class Datasource {
   }
 
   getRequiredFeaturesChain(featureKey: FeatureKey, chain = new Set<FeatureKey>()): Set<FeatureKey> {
-    if (chain.size === 0) {
-      chain.add(featureKey);
-    }
+    chain.add(featureKey);
 
     if (!this.entityExists("feature", featureKey)) {
       throw new Error(`Feature not found: ${featureKey}`);

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -376,60 +376,39 @@ export function getTestsJoiSchema(
   availableFeatureKeys: string[],
   availableSegmentKeys: string[],
 ) {
-  const testsJoiSchema = Joi.object({
-    tests: Joi.array().items(
+  const segmentTestJoiSchema = Joi.object({
+    segment: Joi.string()
+      .valid(...availableSegmentKeys)
+      .required(),
+    assertions: Joi.array().items(
       Joi.object({
         description: Joi.string().optional(),
-        tag: Joi.string()
-          .valid(...projectConfig.tags)
-          .optional(),
-        environment: Joi.string()
-          .valid(...projectConfig.environments)
-          .optional(),
-        features: Joi.array()
-          .items(
-            Joi.object({
-              key: Joi.string()
-                .valid(...availableFeatureKeys)
-                .required(),
-              assertions: Joi.array().items(
-                Joi.object({
-                  description: Joi.string().optional(),
-                  at: Joi.number().precision(3).min(0).max(100),
-                  context: Joi.object(),
-
-                  // @TODO: one or all below
-                  expectedToBeEnabled: Joi.boolean().required(),
-                  expectedVariation: Joi.alternatives().try(
-                    Joi.string(),
-                    Joi.number(),
-                    Joi.boolean(),
-                  ),
-                  expectedVariables: Joi.object(),
-                }),
-              ),
-            }),
-          )
-          .optional(),
-        segments: Joi.array().items(
-          Joi.object({
-            key: Joi.string()
-              .valid(...availableSegmentKeys)
-              .required(),
-            assertions: Joi.array().items(
-              Joi.object({
-                description: Joi.string().optional(),
-                context: Joi.object(),
-                expectedToMatch: Joi.boolean(),
-              }),
-            ),
-          }),
-        ),
+        context: Joi.object(),
+        expectedToMatch: Joi.boolean(),
       }),
     ),
   });
 
-  return testsJoiSchema;
+  const featureTestJoiSchema = Joi.object({
+    feature: Joi.string()
+      .valid(...availableFeatureKeys)
+      .required(),
+    assertions: Joi.array().items(
+      Joi.object({
+        description: Joi.string().optional(),
+        at: Joi.number().precision(3).min(0).max(100),
+        environment: Joi.string().valid(...projectConfig.environments),
+        context: Joi.object(),
+
+        // @TODO: one or all below
+        expectedToBeEnabled: Joi.boolean().required(),
+        expectedVariation: Joi.alternatives().try(Joi.string(), Joi.number(), Joi.boolean()),
+        expectedVariables: Joi.object(),
+      }),
+    ),
+  });
+
+  return Joi.alternatives().try(segmentTestJoiSchema, featureTestJoiSchema);
 }
 
 export function printJoiError(e: Joi.ValidationError) {

--- a/packages/core/src/tester.ts
+++ b/packages/core/src/tester.ts
@@ -1,10 +1,10 @@
 import * as fs from "fs";
 
-import { DatafileContent, Condition } from "@featurevisor/types";
+import { Condition, ExistingState, TestSegment, TestFeature } from "@featurevisor/types";
 import { createInstance, allConditionsAreMatched, MAX_BUCKETED_NUMBER } from "@featurevisor/sdk";
 
-import { ProjectConfig } from "./config";
-import { getDatafilePath } from "./builder";
+import { ProjectConfig, SCHEMA_VERSION } from "./config";
+import { getExistingStateFilePath, buildDatafile } from "./builder";
 import { Datasource } from "./datasource/datasource";
 
 // @TODO: make it better
@@ -71,143 +71,138 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
 
     console.log(`  => Testing: ${testFilePath.replace(rootDirectoryPath, "")}`);
 
-    const parsed = datasource.readTest(testFile);
+    const test = datasource.readTest(testFile);
 
-    parsed.tests.forEach(function (test) {
-      if (test.segments) {
-        // segment testing
-        test.segments.forEach(function (segment) {
-          const segmentKey = segment.key;
+    if ((test as TestSegment).segment) {
+      // segment testing
+      const testSegment = test as TestSegment;
+      const segmentKey = testSegment.segment;
 
-          console.log(`     => Segment "${segmentKey}":`);
+      console.log(`     => Segment "${segmentKey}":`);
 
-          const segmentExists = datasource.entityExists("segment", segmentKey);
+      const segmentExists = datasource.entityExists("segment", segmentKey);
 
-          if (!segmentExists) {
-            console.error(`        => Segment does not exist: ${segmentKey}`);
-            hasError = true;
+      if (!segmentExists) {
+        console.error(`        => Segment does not exist: ${segmentKey}`);
+        hasError = true;
 
-            return;
-          }
+        continue;
+      }
 
-          const parsedSegment = datasource.readSegment(segmentKey);
-          const conditions = parsedSegment.conditions as Condition | Condition[];
+      const parsedSegment = datasource.readSegment(segmentKey);
+      const conditions = parsedSegment.conditions as Condition | Condition[];
 
-          segment.assertions.forEach(function (assertion, aIndex) {
-            const description = assertion.description || `#${aIndex + 1}`;
+      testSegment.assertions.forEach(function (assertion, aIndex) {
+        const description = assertion.description || `#${aIndex + 1}`;
 
-            console.log(`        => Assertion #${aIndex + 1}: ${description}`);
+        console.log(`        => Assertion #${aIndex + 1}: ${description}`);
 
-            const expected = assertion.expectedToMatch;
-            const actual = allConditionsAreMatched(conditions, assertion.context);
+        const expected = assertion.expectedToMatch;
+        const actual = allConditionsAreMatched(conditions, assertion.context);
 
-            if (actual !== expected) {
-              hasError = true;
-
-              console.error(`           Segment failed: expected "${expected}", got "${actual}"`);
-            }
-          });
-        });
-      } else if (test.environment && test.tag && test.features) {
-        // feature testing
-        const datafilePath = getDatafilePath(projectConfig, test.environment, test.tag);
-
-        if (!fs.existsSync(datafilePath)) {
-          console.error(`     => Datafile does not exist: ${datafilePath}`);
+        if (actual !== expected) {
           hasError = true;
 
-          return;
+          console.error(`           Segment failed: expected "${expected}", got "${actual}"`);
         }
+      });
+    } else if ((test as TestFeature).feature) {
+      // feature testing
+      const testFeature = test as TestFeature;
+      const featureKey = testFeature.feature;
 
-        const datafileContent = JSON.parse(
-          fs.readFileSync(datafilePath, "utf8"),
-        ) as DatafileContent;
+      console.log(`     => Feature "${featureKey}":`);
 
-        let currentAt = 0;
+      testFeature.assertions.forEach(function (assertion, aIndex) {
+        const description = assertion.description || `at ${assertion.at}%`;
+
+        console.log(
+          `        => Assertion #${aIndex + 1}: (${assertion.environment}) ${description}`,
+        );
+
+        const datafileContent = buildDatafile(
+          projectConfig,
+          datasource,
+          {
+            schemaVersion: SCHEMA_VERSION,
+            revision: "testing",
+            environment: assertion.environment,
+            features: Array.from(datasource.getRequiredFeaturesChain(testFeature.feature)),
+          },
+          JSON.parse(
+            fs.readFileSync(getExistingStateFilePath(projectConfig, assertion.environment), "utf8"),
+          ) as ExistingState,
+        );
 
         const sdk = createInstance({
           datafile: datafileContent,
           configureBucketValue: () => {
-            return currentAt;
+            return assertion.at * (MAX_BUCKETED_NUMBER / 100);
           },
           // logger: createLogger({
           //   levels: ["debug", "info", "warn", "error"],
           // }),
         });
 
-        test.features.forEach(function (feature) {
-          const featureKey = feature.key;
+        // isEnabled
+        if ("expectedToBeEnabled" in assertion) {
+          const isEnabled = sdk.isEnabled(featureKey, assertion.context);
 
-          console.log(`     => Feature "${featureKey}" in environment "${test.environment}":`);
+          if (isEnabled !== assertion.expectedToBeEnabled) {
+            hasError = true;
 
-          feature.assertions.forEach(function (assertion, aIndex) {
-            const description = assertion.description || `at ${assertion.at}%`;
+            console.error(
+              `           isEnabled failed: expected "${assertion.expectedToBeEnabled}", got "${isEnabled}"`,
+            );
+          }
+        }
 
-            console.log(`        => Assertion #${aIndex + 1}: ${description}`);
+        // variation
+        if ("expectedVariation" in assertion) {
+          const variation = sdk.getVariation(featureKey, assertion.context);
 
-            currentAt = assertion.at * (MAX_BUCKETED_NUMBER / 100);
+          if (variation !== assertion.expectedVariation) {
+            hasError = true;
 
-            // isEnabled
-            if ("expectedToBeEnabled" in assertion) {
-              const isEnabled = sdk.isEnabled(featureKey, assertion.context);
+            console.error(
+              `           Variation failed: expected "${assertion.expectedVariation}", got "${variation}"`,
+            );
+          }
+        }
 
-              if (isEnabled !== assertion.expectedToBeEnabled) {
-                hasError = true;
+        // variables
+        if (typeof assertion.expectedVariables === "object") {
+          Object.keys(assertion.expectedVariables).forEach(function (variableKey) {
+            const expectedValue =
+              assertion.expectedVariables && assertion.expectedVariables[variableKey];
+            const actualValue = sdk.getVariable(featureKey, variableKey, assertion.context);
 
-                console.error(
-                  `           isEnabled failed: expected "${assertion.expectedToBeEnabled}", got "${isEnabled}"`,
-                );
-              }
+            let passed;
+
+            if (typeof expectedValue === "object") {
+              passed = checkIfObjectsAreEqual(expectedValue, actualValue);
+            } else if (Array.isArray(expectedValue)) {
+              passed = checkIfArraysAreEqual(expectedValue, actualValue);
+            } else {
+              passed = expectedValue === actualValue;
             }
 
-            // variation
-            if ("expectedVariation" in assertion) {
-              const variation = sdk.getVariation(featureKey, assertion.context);
+            if (!passed) {
+              hasError = true;
 
-              if (variation !== assertion.expectedVariation) {
-                hasError = true;
-
-                console.error(
-                  `           Variation failed: expected "${assertion.expectedVariation}", got "${variation}"`,
-                );
-              }
-            }
-
-            // variables
-            if (typeof assertion.expectedVariables === "object") {
-              Object.keys(assertion.expectedVariables).forEach(function (variableKey) {
-                const expectedValue =
-                  assertion.expectedVariables && assertion.expectedVariables[variableKey];
-                const actualValue = sdk.getVariable(featureKey, variableKey, assertion.context);
-
-                let passed;
-
-                if (typeof expectedValue === "object") {
-                  passed = checkIfObjectsAreEqual(expectedValue, actualValue);
-                } else if (Array.isArray(expectedValue)) {
-                  passed = checkIfArraysAreEqual(expectedValue, actualValue);
-                } else {
-                  passed = expectedValue === actualValue;
-                }
-
-                if (!passed) {
-                  hasError = true;
-
-                  console.error(
-                    `           Variable "${variableKey}" failed: expected ${JSON.stringify(
-                      expectedValue,
-                    )}, got "${JSON.stringify(actualValue)}"`,
-                  );
-                }
-              });
+              console.error(
+                `           Variable "${variableKey}" failed: expected ${JSON.stringify(
+                  expectedValue,
+                )}, got "${JSON.stringify(actualValue)}"`,
+              );
             }
           });
-        });
-      } else {
-        console.error(`     => Invalid test: ${JSON.stringify(test)}`);
-        hasError = true;
-      }
-    });
+        }
+      });
+    } else {
+      console.error(`     => Invalid test: ${JSON.stringify(test)}`);
+      hasError = true;
+    }
   }
 
   return hasError;

--- a/packages/core/src/tester.ts
+++ b/packages/core/src/tester.ts
@@ -120,6 +120,10 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
           `        => Assertion #${aIndex + 1}: (${assertion.environment}) ${description}`,
         );
 
+        const featuresToInclude = Array.from(
+          datasource.getRequiredFeaturesChain(testFeature.feature),
+        );
+
         const datafileContent = buildDatafile(
           projectConfig,
           datasource,
@@ -127,7 +131,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
             schemaVersion: SCHEMA_VERSION,
             revision: "testing",
             environment: assertion.environment,
-            features: Array.from(datasource.getRequiredFeaturesChain(testFeature.feature)),
+            features: featuresToInclude,
           },
           JSON.parse(
             fs.readFileSync(getExistingStateFilePath(projectConfig, assertion.environment), "utf8"),

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -351,6 +351,7 @@ export interface ExistingState {
  */
 export interface FeatureAssertion {
   description?: string;
+  environment: EnvironmentKey;
   at: Weight; // bucket weight: 0 to 100
   context: Context;
   expectedToBeEnabled: boolean;
@@ -361,7 +362,7 @@ export interface FeatureAssertion {
 }
 
 export interface TestFeature {
-  key: FeatureKey;
+  feature: FeatureKey;
   assertions: FeatureAssertion[];
 }
 
@@ -372,25 +373,11 @@ export interface SegmentAssertion {
 }
 
 export interface TestSegment {
-  key: SegmentKey;
+  segment: SegmentKey;
   assertions: SegmentAssertion[];
 }
 
-export interface Test {
-  description?: string;
-
-  // needed for feature testing
-  tag?: string;
-  environment?: string;
-  features?: TestFeature[];
-
-  // needed for segment testing
-  segments?: TestSegment[];
-}
-
-export interface Spec {
-  tests: Test[];
-}
+export type Test = TestSegment | TestFeature;
 
 /**
  * Site index and history


### PR DESCRIPTION
## What's done

Test specs used to be nested too much, and this happened because feature testing was introduced first, and the same API was later used to also support segments testing: https://featurevisor.com/docs/testing/

This approached helped achieve the result, but not in a very readable way.

Now with the proposed changes they are much more readable, and easy to follow and does not require one to build the datafiles on disk to run tests. The datafiles, when running tests, will be built on the fly without changing anything on disk.

## Segments testing

### Before

```yml
# tests/netherlands.spec.yml
tests:
  - segments:
      - key: netherlands
        assertions:
          - context:
              country: nl
            expectedToMatch: true

          - context:
              country: de
              someOtherAttribute: someOtherValue
            expectedToMatch: false

          - context:
              country: notNl
            expectedToMatch: false
```

### After

```yml
# tests/netherlands.spec.yml
segment: netherlands
assertions:
  - context:
      country: nl
    expectedToMatch: true

  - context:
      country: de
      someOtherAttribute: someOtherValue
    expectedToMatch: false

  - context:
      country: notNl
    expectedToMatch: false
```

## Feature testing

### Before

```yml
# tests/showCookieBanner.spec.yml
tests:
  - tag: all
    environment: production
    features:
      - key: showCookieBanner
        assertions:
          - at: 10
            description: "At 10%, the feature should be enabled for NL"
            context:
              country: nl
            expectedToBeEnabled: true

          - at: 70
            description: "At 70%, the feature should be enabled for NL"
            context:
              country: nl
            expectedToBeEnabled: true

          - at: 90
            description: "At 90%, the feature should be disabled for US"
            context:
              country: us
            expectedToBeEnabled: false

          - at: 90
            description: "At 90%, the feature should be disabled for Canada"
            context:
              country: ca
            expectedToBeEnabled: false
```

### After

```yml
# tests/showCookieBanner.spec.yml
feature: showCookieBanner
assertions:
  - at: 10
    description: "At 10%, the feature should be enabled for NL"
    environment: production
    context:
      country: nl
    expectedToBeEnabled: true

  - at: 70
    description: "At 70%, the feature should be enabled for NL"
    environment: production
    context:
      country: nl
    expectedToBeEnabled: true

  - at: 90
    description: "At 90%, the feature should be disabled for US"
    environment: production
    context:
      country: us
    expectedToBeEnabled: false

  - at: 90
    description: "At 90%, the feature should be disabled for Canada"
    environment: production
    context:
      country: ca
    expectedToBeEnabled: false
```

## Migration

This will only impact you if you are using the testing capabilities of Featurevisor. The SDK and regular feature and segment definitions remain unaffected.

I am taking advantage of the semver principles for v0.x by introducing these little breaking changes so that by the time we have v1.0, the API is really solid and relatively easy to understand.

Thank you for understanding 🙌 