### PR TITLE
chore: Set single Nodejs version source

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version-file: '.nvmrc'
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
## What's done

As a slight improvement, I have set the `actions/setup-nod@v2` GH action to read the node version directly from the `.nvmrc` file. 

This will guarantee that the versions will be updated in future iterations only in a single place. 


Cheers ❤️ 
