### PR TITLE
feat: find duplicate segments from CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,3 +113,13 @@ $ featurevisor generate-code --language typescript --out-dir ./src
 See output in `./src` directory.
 
 Learn more in [code generation](/docs/code-generation) page.
+
+## Find duplicate segments
+
+It is possible to end up with multiple segments having same conditions in larger projects. This is not a problem per se, but we should be aware of it.
+
+We can find these duplicates early on by running:
+
+```
+$ featurevisor find-duplicate-segments
+```

--- a/examples/example-1/package.json
+++ b/examples/example-1/package.json
@@ -9,7 +9,8 @@
     "test": "featurevisor test",
     "export": "featurevisor site export",
     "start": "npm run export && featurevisor site serve",
-    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src"
+    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src",
+    "find-duplicate-segments": "featurevisor find-duplicate-segments"
   },
   "dependencies": {
     "@featurevisor/cli": "^0.52.1"

--- a/examples/example-json/package.json
+++ b/examples/example-json/package.json
@@ -9,7 +9,8 @@
     "test": "featurevisor test",
     "export": "featurevisor site export",
     "start": "npm run export && featurevisor site serve",
-    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src"
+    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src",
+    "find-duplicate-segments": "featurevisor find-duplicate-segments"
   },
   "dependencies": {
     "@featurevisor/cli": "^0.52.1"

--- a/examples/example-toml/package.json
+++ b/examples/example-toml/package.json
@@ -9,7 +9,8 @@
     "test": "featurevisor test",
     "export": "featurevisor site export",
     "start": "npm run export && featurevisor site serve",
-    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src"
+    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src",
+    "find-duplicate-segments": "featurevisor find-duplicate-segments"
   },
   "dependencies": {
     "@featurevisor/cli": "^0.52.1",

--- a/examples/example-yml/package.json
+++ b/examples/example-yml/package.json
@@ -9,7 +9,8 @@
     "test": "featurevisor test",
     "export": "featurevisor site export",
     "start": "npm run export && featurevisor site serve",
-    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src"
+    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src",
+    "find-duplicate-segments": "featurevisor find-duplicate-segments"
   },
   "dependencies": {
     "@featurevisor/cli": "^0.52.1"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import {
   exportSite,
   serveSite,
   generateCodeForProject,
+  findDuplicateSegmentsInProject,
   BuildCLIOptions,
   GenerateCodeCLIOptions,
   restoreProject,
@@ -175,6 +176,24 @@ async function main() {
     })
     .example("$0 generate-code", "generate code from YAMLs")
     .example("$0 generate-code --language typescript --out-dir ./src", "")
+
+    /**
+     * Find duplicate segments
+     */
+    .command({
+      command: "find-duplicate-segments",
+      handler: function () {
+        const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
+
+        try {
+          findDuplicateSegmentsInProject(rootDirectoryPath, projectConfig);
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1);
+        }
+      },
+    })
+    .example("$0 generate-code", "generate code from YAMLs")
 
     /**
      * Options

--- a/packages/core/src/find-duplicate-segments/findDuplicateSegments.ts
+++ b/packages/core/src/find-duplicate-segments/findDuplicateSegments.ts
@@ -1,0 +1,33 @@
+import * as crypto from "crypto";
+
+import { SegmentKey } from "@featurevisor/types";
+
+import { Datasource } from "../datasource";
+
+export function findDuplicateSegments(datasource: Datasource): SegmentKey[][] {
+  const segmentsWithHash = datasource.listSegments().map((segmentKey) => {
+    const segment = datasource.readSegment(segmentKey);
+    const conditions = JSON.stringify(segment.conditions);
+    const hash = crypto.createHash("sha256").update(conditions).digest("hex");
+
+    return {
+      segmentKey,
+      hash,
+    };
+  });
+
+  const groupedSegments: { [hash: string]: SegmentKey[] } = segmentsWithHash.reduce(
+    (acc, { segmentKey, hash }) => {
+      if (!acc[hash]) {
+        acc[hash] = [];
+      }
+      acc[hash].push(segmentKey);
+      return acc;
+    },
+    {},
+  );
+
+  const result = Object.values(groupedSegments).filter((segmentKeys) => segmentKeys.length > 1);
+
+  return result;
+}

--- a/packages/core/src/find-duplicate-segments/index.ts
+++ b/packages/core/src/find-duplicate-segments/index.ts
@@ -1,0 +1,21 @@
+import { Datasource } from "../datasource";
+import { ProjectConfig } from "../config";
+
+import { findDuplicateSegments } from "./findDuplicateSegments";
+
+export function findDuplicateSegmentsInProject(rootDirectoryPath, projectConfig: ProjectConfig) {
+  const datasource = new Datasource(projectConfig);
+
+  const duplicates = findDuplicateSegments(datasource);
+
+  if (duplicates.length === 0) {
+    console.log("No duplicate segments found");
+    return;
+  }
+
+  console.log(`Found ${duplicates.length} duplicates:\n`);
+
+  duplicates.forEach((segmentKeys) => {
+    console.log(`  - ${segmentKeys.join(", ")}`);
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./init";
 export * from "./site";
 export * from "./generate-code";
 export * from "./restore";
+export * from "./find-duplicate-segments";


### PR DESCRIPTION
It is possible to end up with multiple segments having same conditions in larger projects. This is not a problem per se, but we should be aware of it.

We can find these duplicates early on by running:

```
$ featurevisor find-duplicate-segments
```
