### PR TITLE
chore: make datasource async

### DIFF
--- a/examples/example-1/package.json
+++ b/examples/example-1/package.json
@@ -5,7 +5,8 @@
   "description": "For testing only",
   "scripts": {
     "lint": "featurevisor lint",
-    "build": "featurevisor build",
+    "build": "npm run build:datafiles && npm run export && npm run find-duplicate-segments && npm run generate-code",
+    "build:datafiles": "featurevisor build",
     "test": "featurevisor test",
     "export": "featurevisor site export",
     "start": "npm run export && featurevisor site serve",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -78,11 +78,11 @@ async function main() {
 
     .command({
       command: "build",
-      handler: function (options) {
+      handler: async function (options) {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
         try {
-          buildProject(rootDirectoryPath, projectConfig, options as BuildCLIOptions);
+          await buildProject(rootDirectoryPath, projectConfig, options as BuildCLIOptions);
         } catch (e) {
           console.error(e);
           process.exit(1);
@@ -108,10 +108,10 @@ async function main() {
 
     .command({
       command: "test",
-      handler: function () {
+      handler: async function () {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
-        const hasError = testProject(rootDirectoryPath, projectConfig);
+        const hasError = await testProject(rootDirectoryPath, projectConfig);
 
         if (hasError) {
           process.exit(1);
@@ -125,7 +125,7 @@ async function main() {
      */
     .command({
       command: "site [subcommand]",
-      handler: function (options) {
+      handler: async function (options) {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
         const allowedSubcommands = ["export", "serve"];
@@ -137,7 +137,7 @@ async function main() {
 
         // export
         if (options.subcommand === "export") {
-          const hasError = exportSite(rootDirectoryPath, projectConfig);
+          const hasError = await exportSite(rootDirectoryPath, projectConfig);
 
           if (hasError) {
             process.exit(1);
@@ -159,11 +159,11 @@ async function main() {
      */
     .command({
       command: "generate-code",
-      handler: function (options) {
+      handler: async function (options) {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
         try {
-          generateCodeForProject(
+          await generateCodeForProject(
             rootDirectoryPath,
             projectConfig,
             options as unknown as GenerateCodeCLIOptions,
@@ -182,11 +182,11 @@ async function main() {
      */
     .command({
       command: "find-duplicate-segments",
-      handler: function () {
+      handler: async function () {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
         try {
-          findDuplicateSegmentsInProject(rootDirectoryPath, projectConfig);
+          await findDuplicateSegmentsInProject(rootDirectoryPath, projectConfig);
         } catch (e) {
           console.error(e.message);
           process.exit(1);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -47,7 +47,7 @@ async function main() {
     .usage("Usage: <command> [options]")
 
     /**
-     * Commands
+     * Init
      */
     .command({
       command: "init",
@@ -62,6 +62,9 @@ async function main() {
     .example("$0 init", "scaffold a new project")
     .example("$0 init --example=exampleName", "scaffold a new project from known example")
 
+    /**
+     * Lint
+     */
     .command({
       command: "lint",
       handler: async function () {
@@ -76,6 +79,9 @@ async function main() {
     })
     .example("$0 lint", "lint all YAML file content")
 
+    /**
+     * Build
+     */
     .command({
       command: "build",
       handler: async function (options) {
@@ -91,13 +97,16 @@ async function main() {
     })
     .example("$0 build", "build datafiles")
 
+    /**
+     * Restore
+     */
     .command({
       command: "restore",
-      handler: function () {
+      handler: async function () {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
         try {
-          restoreProject(rootDirectoryPath, projectConfig);
+          await restoreProject(rootDirectoryPath, projectConfig);
         } catch (e) {
           console.error(e.message);
           process.exit(1);
@@ -106,6 +115,9 @@ async function main() {
     })
     .example("$0 restore", "restore state files")
 
+    /**
+     * Test
+     */
     .command({
       command: "test",
       handler: async function () {

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -33,12 +33,12 @@ export interface BuildOptions {
   features?: FeatureKey[];
 }
 
-export function buildDatafile(
+export async function buildDatafile(
   projectConfig: ProjectConfig,
   datasource: Datasource,
   options: BuildOptions,
   existingState: ExistingState,
-): DatafileContent {
+): Promise<DatafileContent> {
   const datafileContent: DatafileContent = {
     schemaVersion: options.schemaVersion,
     revision: options.revision,
@@ -49,17 +49,17 @@ export function buildDatafile(
 
   const segmentKeysUsedByTag = new Set<SegmentKey>();
   const attributeKeysUsedByTag = new Set<AttributeKey>();
-  const { featureRanges, featureIsInGroup } = getFeatureRanges(projectConfig, datasource);
+  const { featureRanges, featureIsInGroup } = await getFeatureRanges(projectConfig, datasource);
 
   // features
   const features: Feature[] = [];
   const featuresDirectory = projectConfig.featuresDirectoryPath;
 
   if (fs.existsSync(featuresDirectory)) {
-    const featureFiles = datasource.listFeatures();
+    const featureFiles = await datasource.listFeatures();
 
     for (const featureKey of featureFiles) {
-      const parsedFeature = datasource.readFeature(featureKey);
+      const parsedFeature = await datasource.readFeature(featureKey);
 
       if (parsedFeature.archived === true) {
         continue;
@@ -200,10 +200,10 @@ export function buildDatafile(
   const segmentsDirectory = projectConfig.segmentsDirectoryPath;
 
   if (fs.existsSync(segmentsDirectory)) {
-    const segmentFiles = datasource.listSegments();
+    const segmentFiles = await datasource.listSegments();
 
     for (const segmentKey of segmentFiles) {
-      const parsedSegment = datasource.readSegment(segmentKey);
+      const parsedSegment = await datasource.readSegment(segmentKey);
 
       if (parsedSegment.archived === true) {
         continue;
@@ -235,10 +235,10 @@ export function buildDatafile(
   const attributesDirectory = projectConfig.attributesDirectoryPath;
 
   if (fs.existsSync(attributesDirectory)) {
-    const attributeFiles = datasource.listAttributes();
+    const attributeFiles = await datasource.listAttributes();
 
     for (const attributeKey of attributeFiles) {
-      const parsedAttribute = datasource.readAttribute(attributeKey);
+      const parsedAttribute = await datasource.readAttribute(attributeKey);
 
       if (parsedAttribute.archived === true) {
         continue;

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -31,7 +31,7 @@ export interface BuildCLIOptions {
   revision?: string;
 }
 
-export function buildProject(
+export async function buildProject(
   rootDirectoryPath,
   projectConfig: ProjectConfig,
   cliOptions: BuildCLIOptions = {},
@@ -54,7 +54,7 @@ export function buildProject(
 
     for (const tag of tags) {
       console.log(`\n  => Tag: ${tag}`);
-      const datafileContent = buildDatafile(
+      const datafileContent = await buildDatafile(
         projectConfig,
         datasource,
         {

--- a/packages/core/src/builder/getFeatureRanges.ts
+++ b/packages/core/src/builder/getFeatureRanges.ts
@@ -12,19 +12,19 @@ export interface FeatureRangesResult {
   featureIsInGroup: { [key: string]: boolean };
 }
 
-export function getFeatureRanges(
+export async function getFeatureRanges(
   projectConfig: ProjectConfig,
   datasource: Datasource,
-): FeatureRangesResult {
+): Promise<FeatureRangesResult> {
   const featureRanges = new Map<FeatureKey, Range[]>();
   const featureIsInGroup = {}; // featureKey => boolean
 
   const groups: Group[] = [];
   if (fs.existsSync(projectConfig.groupsDirectoryPath)) {
-    const groupFiles = datasource.listGroups();
+    const groupFiles = await datasource.listGroups();
 
     for (const groupKey of groupFiles) {
-      const parsedGroup = datasource.readGroup(groupKey);
+      const parsedGroup = await datasource.readGroup(groupKey);
 
       groups.push({
         ...parsedGroup,

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -87,7 +87,7 @@ export class Datasource {
   }
 
   async parseEntity<T>(entityType: EntityType, entityKey: string): Promise<T> {
-    const entityContent = this.readEntity(entityType, entityKey);
+    const entityContent = await this.readEntity(entityType, entityKey);
 
     return this.parse(entityContent) as T;
   }

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -1,15 +1,7 @@
 import * as path from "path";
 import * as fs from "fs";
 
-import {
-  Tag,
-  ParsedFeature,
-  Segment,
-  Attribute,
-  Group,
-  FeatureKey,
-  Test,
-} from "@featurevisor/types";
+import { ParsedFeature, Segment, Attribute, Group, FeatureKey, Test } from "@featurevisor/types";
 
 import { ProjectConfig } from "../config";
 import { parsers } from "./parsers";
@@ -53,7 +45,7 @@ export class Datasource {
   /**
    * Common methods
    */
-  listEntities(entityType: EntityType): string[] {
+  async listEntities(entityType: EntityType): Promise<string[]> {
     const directoryPath = this.getEntityDirectoryPath(entityType);
 
     return fs
@@ -82,19 +74,19 @@ export class Datasource {
     return path.join(basePath, `${entityKey}.${this.extension}`);
   }
 
-  entityExists(entityType: EntityType, entityKey: string): boolean {
+  async entityExists(entityType: EntityType, entityKey: string): Promise<boolean> {
     const entityPath = this.getEntityPath(entityType, entityKey);
 
     return fs.existsSync(entityPath);
   }
 
-  readEntity(entityType: EntityType, entityKey: string): string {
+  async readEntity(entityType: EntityType, entityKey: string): Promise<string> {
     const filePath = this.getEntityPath(entityType, entityKey);
 
     return fs.readFileSync(filePath, "utf8");
   }
 
-  parseEntity<T>(entityType: EntityType, entityKey: string): T {
+  async parseEntity<T>(entityType: EntityType, entityKey: string): Promise<T> {
     const entityContent = this.readEntity(entityType, entityKey);
 
     return this.parse(entityContent) as T;
@@ -105,61 +97,46 @@ export class Datasource {
    */
 
   // features
-  listFeatures(tag?: Tag) {
-    const features = this.listEntities("feature");
-
-    if (tag) {
-      return features.filter((feature) => {
-        const featureContent = this.parseEntity<ParsedFeature>("feature", feature);
-
-        return featureContent.tags.indexOf(tag) !== -1;
-      });
-    }
-
-    return features;
+  async listFeatures() {
+    return await this.listEntities("feature");
   }
 
   readFeature(featureKey: string) {
     return this.parseEntity<ParsedFeature>("feature", featureKey);
   }
 
-  getRequiredFeaturesChain(featureKey: FeatureKey, chain = new Set<FeatureKey>()): Set<FeatureKey> {
+  async getRequiredFeaturesChain(
+    featureKey: FeatureKey,
+    chain = new Set<FeatureKey>(),
+  ): Promise<Set<FeatureKey>> {
     chain.add(featureKey);
 
     if (!this.entityExists("feature", featureKey)) {
       throw new Error(`Feature not found: ${featureKey}`);
     }
 
-    const feature = this.readFeature(featureKey);
+    const feature = await this.readFeature(featureKey);
 
     if (!feature.required) {
       return chain;
     }
 
-    feature.required.forEach((r) => {
+    for (const r of feature.required) {
       const requiredKey = typeof r === "string" ? r : r.key;
 
       if (chain.has(requiredKey)) {
         throw new Error(`Circular dependency detected: ${chain.toString()}`);
       }
 
-      this.getRequiredFeaturesChain(requiredKey, chain);
-    });
+      await this.getRequiredFeaturesChain(requiredKey, chain);
+    }
 
     return chain;
   }
 
   // segments
-  listSegments(segmentsList?: string[]) {
-    const segments = this.listEntities("segment");
-
-    if (segmentsList) {
-      return segments.filter((segment) => {
-        return segmentsList.indexOf(segment) !== -1;
-      });
-    }
-
-    return segments;
+  listSegments() {
+    return this.listEntities("segment");
   }
 
   readSegment(segmentKey: string) {
@@ -167,16 +144,8 @@ export class Datasource {
   }
 
   // attributes
-  listAttributes(attributesList?: string[]) {
-    const attributes = this.listEntities("attribute");
-
-    if (attributesList) {
-      return attributes.filter((segment) => {
-        return attributesList.indexOf(segment) !== -1;
-      });
-    }
-
-    return attributes;
+  listAttributes() {
+    return this.listEntities("attribute");
   }
 
   readAttribute(attributeKey: string) {
@@ -184,24 +153,8 @@ export class Datasource {
   }
 
   // groups
-  listGroups(featuresList?: string[]) {
-    const groups = this.listEntities("group");
-
-    if (featuresList) {
-      return groups.filter((group) => {
-        const groupContent = this.parseEntity<Group>("group", group);
-
-        return groupContent.slots.some((slot) => {
-          if (!slot.feature) {
-            return false;
-          }
-
-          return featuresList.indexOf(slot.feature) !== -1;
-        });
-      });
-    }
-
-    return groups;
+  async listGroups() {
+    return this.listEntities("group");
   }
 
   readGroup(groupKey: string) {

--- a/packages/core/src/find-duplicate-segments/findDuplicateSegments.ts
+++ b/packages/core/src/find-duplicate-segments/findDuplicateSegments.ts
@@ -4,17 +4,20 @@ import { SegmentKey } from "@featurevisor/types";
 
 import { Datasource } from "../datasource";
 
-export function findDuplicateSegments(datasource: Datasource): SegmentKey[][] {
-  const segmentsWithHash = datasource.listSegments().map((segmentKey) => {
-    const segment = datasource.readSegment(segmentKey);
+export async function findDuplicateSegments(datasource: Datasource): Promise<SegmentKey[][]> {
+  const segments = await datasource.listSegments();
+
+  const segmentsWithHash: { segmentKey: SegmentKey; hash: string }[] = [];
+  for (const segmentKey of segments) {
+    const segment = await datasource.readSegment(segmentKey);
     const conditions = JSON.stringify(segment.conditions);
     const hash = crypto.createHash("sha256").update(conditions).digest("hex");
 
-    return {
+    segmentsWithHash.push({
       segmentKey,
       hash,
-    };
-  });
+    });
+  }
 
   const groupedSegments: { [hash: string]: SegmentKey[] } = segmentsWithHash.reduce(
     (acc, { segmentKey, hash }) => {

--- a/packages/core/src/find-duplicate-segments/index.ts
+++ b/packages/core/src/find-duplicate-segments/index.ts
@@ -3,10 +3,13 @@ import { ProjectConfig } from "../config";
 
 import { findDuplicateSegments } from "./findDuplicateSegments";
 
-export function findDuplicateSegmentsInProject(rootDirectoryPath, projectConfig: ProjectConfig) {
+export async function findDuplicateSegmentsInProject(
+  rootDirectoryPath,
+  projectConfig: ProjectConfig,
+) {
   const datasource = new Datasource(projectConfig);
 
-  const duplicates = findDuplicateSegments(datasource);
+  const duplicates = await findDuplicateSegments(datasource);
 
   if (duplicates.length === 0) {
     console.log("No duplicate segments found");

--- a/packages/core/src/generate-code/index.ts
+++ b/packages/core/src/generate-code/index.ts
@@ -14,7 +14,7 @@ export interface GenerateCodeCLIOptions {
   outDir: string;
 }
 
-export function generateCodeForProject(
+export async function generateCodeForProject(
   rootDirectoryPath,
   projectConfig: ProjectConfig,
   cliOptions: GenerateCodeCLIOptions,
@@ -47,7 +47,7 @@ export function generateCodeForProject(
   }
 
   if (cliOptions.language === "typescript") {
-    return generateTypeScriptCodeForProject(
+    return await generateTypeScriptCodeForProject(
       rootDirectoryPath,
       projectConfig,
       datasource,

--- a/packages/core/src/generate-code/typescript.ts
+++ b/packages/core/src/generate-code/typescript.ts
@@ -38,6 +38,16 @@ function getPascalCase(str) {
   return pascalCased;
 }
 
+function getRelativePath(from, to) {
+  const relativePath = path.relative(from, to);
+
+  if (relativePath.startsWith("..")) {
+    return path.join(".", relativePath);
+  }
+
+  return relativePath;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getFeaturevisorTypeFromValue(value) {
   if (typeof value === "boolean") {
@@ -83,12 +93,12 @@ export async function generateTypeScriptCodeForProject(
   datasource: Datasource,
   outputPath: string,
 ) {
-  console.log("Generating TypeScript code...");
+  console.log("\nGenerating TypeScript code...\n");
 
   // instance
   const instanceFilePath = path.join(outputPath, "instance.ts");
   fs.writeFileSync(instanceFilePath, instanceSnippet);
-  console.log(`Instance file written at: ${instanceFilePath}`);
+  console.log(`Instance file written at: ${getRelativePath(rootDirectoryPath, instanceFilePath)}`);
 
   // attributes
   const attributeFiles = await datasource.listAttributes();
@@ -126,7 +136,9 @@ ${attributeProperties}
 
   const contextTypeFilePath = path.join(outputPath, "Context.ts");
   fs.writeFileSync(contextTypeFilePath, contextContent);
-  console.log(`Context type file written at: ${contextTypeFilePath}`);
+  console.log(
+    `Context type file written at: ${getRelativePath(rootDirectoryPath, contextTypeFilePath)}`,
+  );
 
   // features
   const featureNamespaces: string[] = [];
@@ -188,7 +200,12 @@ export namespace ${namespaceValue} {
 
     const featureNamespaceFilePath = path.join(outputPath, `${namespaceValue}.ts`);
     fs.writeFileSync(featureNamespaceFilePath, featureContent);
-    console.log(`Feature ${featureKey} file written at: ${featureNamespaceFilePath}`);
+    console.log(
+      `Feature ${featureKey} file written at: ${getRelativePath(
+        rootDirectoryPath,
+        featureNamespaceFilePath,
+      )}`,
+    );
   }
 
   // index
@@ -202,5 +219,5 @@ export namespace ${namespaceValue} {
       .join("\n") + "\n";
   const indexFilePath = path.join(outputPath, "index.ts");
   fs.writeFileSync(indexFilePath, indexContent);
-  console.log(`Index file written at: ${indexFilePath}`);
+  console.log(`Index file written at: ${getRelativePath(rootDirectoryPath, indexFilePath)}`);
 }

--- a/packages/core/src/linter/checkCircularDependency.ts
+++ b/packages/core/src/linter/checkCircularDependency.ts
@@ -2,7 +2,7 @@ import { FeatureKey, Required } from "@featurevisor/types";
 
 import { Datasource } from "../datasource";
 
-export function checkForCircularDependencyInRequired(
+export async function checkForCircularDependencyInRequired(
   datasource: Datasource,
   featureKey: FeatureKey,
   required?: Required[],
@@ -25,16 +25,16 @@ export function checkForCircularDependencyInRequired(
       throw new Error(`circular dependency found: ${chain.join(" -> ")}`);
     }
 
-    const requiredFeatureExists = datasource.entityExists("feature", requiredKey);
+    const requiredFeatureExists = await datasource.entityExists("feature", requiredKey);
 
     if (!requiredFeatureExists) {
       throw new Error(`required feature "${requiredKey}" not found`);
     }
 
-    const requiredParsedFeature = datasource.readFeature(requiredKey);
+    const requiredParsedFeature = await datasource.readFeature(requiredKey);
 
     if (requiredParsedFeature.required) {
-      checkForCircularDependencyInRequired(
+      await checkForCircularDependencyInRequired(
         datasource,
         featureKey,
         requiredParsedFeature.required,

--- a/packages/core/src/linter/groupSchema.ts
+++ b/packages/core/src/linter/groupSchema.ts
@@ -17,7 +17,7 @@ export function getGroupJoiSchema(
           percentage: Joi.number().precision(3).min(0).max(100),
         }),
       )
-      .custom(function (value) {
+      .custom(async function (value) {
         const totalPercentage = value.reduce((acc, slot) => acc + slot.percentage, 0);
 
         if (totalPercentage !== 100) {
@@ -29,13 +29,13 @@ export function getGroupJoiSchema(
 
           if (slot.feature) {
             const featureKey = slot.feature;
-            const featureExists = datasource.entityExists("feature", featureKey);
+            const featureExists = availableFeatureKeys.indexOf(featureKey) > -1;
 
             if (!featureExists) {
               throw new Error(`feature ${featureKey} not found`);
             }
 
-            const parsedFeature = datasource.readFeature(featureKey);
+            const parsedFeature = await datasource.readFeature(featureKey);
 
             const environmentKeys = Object.keys(parsedFeature.environments);
             for (const environmentKey of environmentKeys) {

--- a/packages/core/src/linter/lintProject.ts
+++ b/packages/core/src/linter/lintProject.ts
@@ -25,7 +25,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   const availableFeatureKeys: string[] = [];
 
   // lint attributes
-  const attributes = datasource.listAttributes();
+  const attributes = await datasource.listAttributes();
   console.log(`Linting ${attributes.length} attributes...\n`);
 
   const attributeJoiSchema = getAttributeJoiSchema();
@@ -50,7 +50,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   }
 
   // lint segments
-  const segments = datasource.listSegments();
+  const segments = await datasource.listSegments();
   console.log(`\nLinting ${segments.length} segments...\n`);
 
   const conditionsJoiSchema = getConditionsJoiSchema(projectConfig, availableAttributeKeys);
@@ -78,7 +78,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   // lint groups
 
   if (fs.existsSync(projectConfig.groupsDirectoryPath)) {
-    const groups = datasource.listGroups();
+    const groups = await datasource.listGroups();
     console.log(`\nLinting ${groups.length} groups...\n`);
 
     // @TODO: feature it slots can be from availableFeatureKeys only
@@ -106,7 +106,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   // @TODO: feature cannot exist in multiple groups
 
   // lint features
-  const features = datasource.listFeatures();
+  const features = await datasource.listFeatures();
   console.log(`\nLinting ${features.length} features...\n`);
 
   const featureJoiSchema = getFeatureJoiSchema(
@@ -117,7 +117,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   );
 
   for (const key of features) {
-    const parsed = datasource.readFeature(key);
+    const parsed = await datasource.readFeature(key);
     availableFeatureKeys.push(key);
 
     try {
@@ -136,7 +136,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
 
     if (parsed.required) {
       try {
-        checkForCircularDependencyInRequired(datasource, key, parsed.required);
+        await checkForCircularDependencyInRequired(datasource, key, parsed.required);
       } catch (e) {
         console.log("  =>", key);
         console.log("     => Error:", e.message);
@@ -147,7 +147,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
 
   // lint tests
   if (fs.existsSync(projectConfig.testsDirectoryPath)) {
-    const tests = datasource.listTests();
+    const tests = await datasource.listTests();
     console.log(`\nLinting ${tests.length} tests...\n`);
 
     const testsJoiSchema = getTestsJoiSchema(

--- a/packages/core/src/restore.ts
+++ b/packages/core/src/restore.ts
@@ -3,7 +3,7 @@ import { execSync } from "child_process";
 
 import { ProjectConfig } from "./config";
 
-export function restoreProject(rootDirectoryPath, projectConfig: ProjectConfig) {
+export async function restoreProject(rootDirectoryPath, projectConfig: ProjectConfig) {
   const relativeStateDirPath = path.relative(rootDirectoryPath, projectConfig.stateDirectoryPath);
   const cmd = `git checkout -- ${relativeStateDirPath}${path.sep}`;
 

--- a/packages/core/src/site/exportSite.ts
+++ b/packages/core/src/site/exportSite.ts
@@ -9,7 +9,7 @@ import { generateHistory } from "./generateHistory";
 import { getRepoDetails } from "./getRepoDetails";
 import { generateSiteSearchIndex } from "./generateSiteSearchIndex";
 
-export function exportSite(rootDirectoryPath: string, projectConfig: ProjectConfig) {
+export async function exportSite(rootDirectoryPath: string, projectConfig: ProjectConfig) {
   const hasError = false;
 
   mkdirp.sync(projectConfig.siteExportDirectoryPath);
@@ -30,7 +30,7 @@ export function exportSite(rootDirectoryPath: string, projectConfig: ProjectConf
 
   // site search index
   const repoDetails = getRepoDetails();
-  const searchIndex = generateSiteSearchIndex(
+  const searchIndex = await generateSiteSearchIndex(
     rootDirectoryPath,
     projectConfig,
     fullHistory,

--- a/packages/core/src/site/generateSiteSearchIndex.ts
+++ b/packages/core/src/site/generateSiteSearchIndex.ts
@@ -15,12 +15,12 @@ import { getRelativePaths } from "./getRelativePaths";
 import { getLastModifiedFromHistory } from "./getLastModifiedFromHistory";
 import { RepoDetails } from "./getRepoDetails";
 
-export function generateSiteSearchIndex(
+export async function generateSiteSearchIndex(
   rootDirectoryPath: string,
   projectConfig: ProjectConfig,
   fullHistory: HistoryEntry[],
   repoDetails: RepoDetails | undefined,
-): SearchIndex {
+): Promise<SearchIndex> {
   const result: SearchIndex = {
     links: undefined,
     entities: {
@@ -77,9 +77,9 @@ export function generateSiteSearchIndex(
   } = {};
 
   // features
-  const featureFiles = datasource.listFeatures();
-  featureFiles.forEach((entityName) => {
-    const parsed = datasource.readFeature(entityName);
+  const featureFiles = await datasource.listFeatures();
+  for (const entityName of featureFiles) {
+    const parsed = await datasource.readFeature(entityName);
 
     if (Array.isArray(parsed.variations)) {
       parsed.variations.forEach((variation) => {
@@ -160,12 +160,12 @@ export function generateSiteSearchIndex(
       key: entityName,
       lastModified: getLastModifiedFromHistory(fullHistory, "feature", entityName),
     });
-  });
+  }
 
   // segments
-  const segmentFiles = datasource.listSegments();
-  segmentFiles.forEach((entityName) => {
-    const parsed = datasource.readSegment(entityName);
+  const segmentFiles = await datasource.listSegments();
+  for (const entityName of segmentFiles) {
+    const parsed = await datasource.readSegment(entityName);
 
     extractAttributeKeysFromConditions(parsed.conditions as Condition | Condition[]).forEach(
       (attributeKey) => {
@@ -183,12 +183,12 @@ export function generateSiteSearchIndex(
       lastModified: getLastModifiedFromHistory(fullHistory, "segment", entityName),
       usedInFeatures: Array.from(segmentsUsedInFeatures[entityName] || []),
     });
-  });
+  }
 
   // attributes
-  const attributeFiles = datasource.listAttributes();
-  attributeFiles.forEach((entityName) => {
-    const parsed = datasource.readAttribute(entityName);
+  const attributeFiles = await datasource.listAttributes();
+  for (const entityName of attributeFiles) {
+    const parsed = await datasource.readAttribute(entityName);
 
     result.entities.attributes.push({
       ...parsed,
@@ -197,7 +197,7 @@ export function generateSiteSearchIndex(
       usedInFeatures: Array.from(attributesUsedInFeatures[entityName] || []),
       usedInSegments: Array.from(attributesUsedInSegments[entityName] || []),
     });
-  });
+  }
 
   return result;
 }

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -12,24 +12,26 @@ import { checkIfArraysAreEqual } from "./checkIfArraysAreEqual";
 import { checkIfObjectsAreEqual } from "./checkIfObjectsAreEqual";
 import { CLI_FORMAT_BOLD, CLI_FORMAT_RED } from "./cliFormat";
 
-export function testFeature(
+export async function testFeature(
   datasource: Datasource,
   projectConfig: ProjectConfig,
   test: TestFeature,
-): boolean {
+): Promise<boolean> {
   let hasError = false;
   const featureKey = test.feature;
 
   console.log(CLI_FORMAT_BOLD, `  Feature "${featureKey}":`);
 
-  test.assertions.forEach(function (assertion, aIndex) {
+  for (let aIndex = 0; aIndex < test.assertions.length; aIndex++) {
+    const assertion = test.assertions[aIndex];
     const description = assertion.description || `at ${assertion.at}%`;
 
     console.log(`  Assertion #${aIndex + 1}: (${assertion.environment}) ${description}`);
 
-    const featuresToInclude = Array.from(datasource.getRequiredFeaturesChain(test.feature));
+    const requiredChain = await datasource.getRequiredFeaturesChain(test.feature);
+    const featuresToInclude = Array.from(requiredChain);
 
-    const datafileContent = buildDatafile(
+    const datafileContent = await buildDatafile(
       projectConfig,
       datasource,
       {
@@ -110,7 +112,7 @@ export function testFeature(
         }
       });
     }
-  });
+  }
 
   return hasError;
 }

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -9,7 +9,10 @@ import { testSegment } from "./testSegment";
 import { testFeature } from "./testFeature";
 import { CLI_FORMAT_BOLD, CLI_FORMAT_GREEN, CLI_FORMAT_RED } from "./cliFormat";
 
-export function testProject(rootDirectoryPath: string, projectConfig: ProjectConfig): boolean {
+export async function testProject(
+  rootDirectoryPath: string,
+  projectConfig: ProjectConfig,
+): Promise<boolean> {
   let hasError = false;
   const datasource = new Datasource(projectConfig);
 
@@ -20,7 +23,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
     return hasError;
   }
 
-  const testFiles = datasource.listTests();
+  const testFiles = await datasource.listTests();
 
   if (testFiles.length === 0) {
     console.error(`No tests found in: ${projectConfig.testsDirectoryPath}`);
@@ -35,13 +38,13 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
     console.log("");
     console.log(CLI_FORMAT_BOLD, `Testing: ${testFilePath.replace(rootDirectoryPath, "")}`);
 
-    const t = datasource.readTest(testFile);
+    const t = await datasource.readTest(testFile);
 
     if ((t as TestSegment).segment) {
       // segment testing
       const test = t as TestSegment;
 
-      const segmentHasError = testSegment(datasource, test);
+      const segmentHasError = await testSegment(datasource, test);
 
       if (segmentHasError) {
         hasError = true;
@@ -50,7 +53,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
       // feature testing
       const test = t as TestFeature;
 
-      const featureHasError = testFeature(datasource, projectConfig, test);
+      const featureHasError = await testFeature(datasource, projectConfig, test);
 
       if (featureHasError) {
         hasError = true;

--- a/packages/core/src/tester/testSegment.ts
+++ b/packages/core/src/tester/testSegment.ts
@@ -5,14 +5,14 @@ import { Datasource } from "../datasource";
 
 import { CLI_FORMAT_BOLD, CLI_FORMAT_RED } from "./cliFormat";
 
-export function testSegment(datasource: Datasource, test: TestSegment): boolean {
+export async function testSegment(datasource: Datasource, test: TestSegment): Promise<boolean> {
   let hasError = false;
 
   const segmentKey = test.segment;
 
   console.log(CLI_FORMAT_BOLD, `  Segment "${segmentKey}":`);
 
-  const segmentExists = datasource.entityExists("segment", segmentKey);
+  const segmentExists = await datasource.entityExists("segment", segmentKey);
 
   if (!segmentExists) {
     console.error(CLI_FORMAT_RED, `  Segment does not exist: ${segmentKey}`);
@@ -21,7 +21,7 @@ export function testSegment(datasource: Datasource, test: TestSegment): boolean 
     return hasError;
   }
 
-  const parsedSegment = datasource.readSegment(segmentKey);
+  const parsedSegment = await datasource.readSegment(segmentKey);
   const conditions = parsedSegment.conditions as Condition | Condition[];
 
   test.assertions.forEach(function (assertion, aIndex) {


### PR DESCRIPTION
## Currently

Datasource is synchronous, and uses the filesystem directly.

## This PR and future

To keep PRs incremental and relatively small, this is the first PR to make datasource methods async.

Future PRs will tackle:

- All read/write operations happening via Datasource instance
- Custom parser API to include both `parse` and `stringify` functions
- Datasource will introduce an adapter pattern, where Filesystem will be one of them (used as default)
- Datasource instance will be passed from CLI runner directly

## Note

This is NOT a breaking change in anyway, and is only affecting the internals.