### PR TITLE
chore: inject dependencies from CLI runner

### DIFF
--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -6,9 +6,9 @@ import * as mkdirp from "mkdirp";
 import { ExistingState, EnvironmentKey } from "@featurevisor/types";
 
 import { SCHEMA_VERSION, ProjectConfig } from "../config";
-import { Datasource } from "../datasource";
 
 import { buildDatafile } from "./buildDatafile";
+import { Dependencies } from "../dependencies";
 
 export function getDatafilePath(
   projectConfig: ProjectConfig,
@@ -24,16 +24,13 @@ export interface BuildCLIOptions {
   revision?: string;
 }
 
-export async function buildProject(
-  rootDirectoryPath,
-  projectConfig: ProjectConfig,
-  cliOptions: BuildCLIOptions = {},
-) {
+export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptions = {}) {
+  const { rootDirectoryPath, projectConfig, datasource } = deps;
+
   const tags = projectConfig.tags;
   const environments = projectConfig.environments;
 
   const pkg = require(path.join(rootDirectoryPath, "package.json"));
-  const datasource = new Datasource(projectConfig);
 
   for (const environment of environments) {
     console.log(`\nBuilding datafiles for environment: ${environment}`);

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -1,0 +1,13 @@
+import { ProjectConfig } from "./config";
+import { Datasource } from "./datasource";
+
+export interface Options {
+  [key: string]: any;
+}
+
+export interface Dependencies {
+  rootDirectoryPath: string;
+  projectConfig: ProjectConfig;
+  datasource: Datasource;
+  options: Options;
+}

--- a/packages/core/src/find-duplicate-segments/index.ts
+++ b/packages/core/src/find-duplicate-segments/index.ts
@@ -1,13 +1,8 @@
-import { Datasource } from "../datasource";
-import { ProjectConfig } from "../config";
-
 import { findDuplicateSegments } from "./findDuplicateSegments";
+import { Dependencies } from "../dependencies";
 
-export async function findDuplicateSegmentsInProject(
-  rootDirectoryPath,
-  projectConfig: ProjectConfig,
-) {
-  const datasource = new Datasource(projectConfig);
+export async function findDuplicateSegmentsInProject(deps: Dependencies) {
+  const { datasource } = deps;
 
   const duplicates = await findDuplicateSegments(datasource);
 

--- a/packages/core/src/generate-code/index.ts
+++ b/packages/core/src/generate-code/index.ts
@@ -3,9 +3,8 @@ import * as path from "path";
 
 import * as mkdirp from "mkdirp";
 
-import { ProjectConfig } from "../config";
-import { Datasource } from "../datasource";
 import { generateTypeScriptCodeForProject } from "./typescript";
+import { Dependencies } from "../dependencies";
 
 export const ALLOWED_LANGUAGES_FOR_CODE_GENERATION = ["typescript"];
 
@@ -15,10 +14,11 @@ export interface GenerateCodeCLIOptions {
 }
 
 export async function generateCodeForProject(
-  rootDirectoryPath,
-  projectConfig: ProjectConfig,
+  deps: Dependencies,
   cliOptions: GenerateCodeCLIOptions,
 ) {
+  const { rootDirectoryPath } = deps;
+
   if (!cliOptions.language) {
     throw new Error("Option `--language` is required");
   }
@@ -26,8 +26,6 @@ export async function generateCodeForProject(
   if (!cliOptions.outDir) {
     throw new Error("Option `--out-dir` is required");
   }
-
-  const datasource = new Datasource(projectConfig);
 
   const absolutePath = path.resolve(rootDirectoryPath, cliOptions.outDir);
 
@@ -47,12 +45,7 @@ export async function generateCodeForProject(
   }
 
   if (cliOptions.language === "typescript") {
-    return await generateTypeScriptCodeForProject(
-      rootDirectoryPath,
-      projectConfig,
-      datasource,
-      absolutePath,
-    );
+    return await generateTypeScriptCodeForProject(deps, absolutePath);
   }
 
   throw new Error(`Language ${cliOptions.language} is not supported`);

--- a/packages/core/src/generate-code/typescript.ts
+++ b/packages/core/src/generate-code/typescript.ts
@@ -1,9 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { ProjectConfig } from "../config";
-import { Datasource } from "../datasource";
 import { Attribute } from "@featurevisor/types";
+import { Dependencies } from "../dependencies";
 
 function convertFeaturevisorTypeToTypeScriptType(featurevisorType: string) {
   switch (featurevisorType) {
@@ -87,12 +86,9 @@ export function getInstance(): FeaturevisorInstance {
 }
 `.trimStart();
 
-export async function generateTypeScriptCodeForProject(
-  rootDirectoryPath: string,
-  projectConfig: ProjectConfig,
-  datasource: Datasource,
-  outputPath: string,
-) {
+export async function generateTypeScriptCodeForProject(deps: Dependencies, outputPath: string) {
+  const { rootDirectoryPath, datasource } = deps;
+
   console.log("\nGenerating TypeScript code...\n");
 
   // instance

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,3 +7,5 @@ export * from "./site";
 export * from "./generate-code";
 export * from "./restore";
 export * from "./find-duplicate-segments";
+export * from "./dependencies";
+export * from "./datasource";

--- a/packages/core/src/linter/lintProject.ts
+++ b/packages/core/src/linter/lintProject.ts
@@ -1,9 +1,6 @@
 // for use in node only
 import * as Joi from "joi";
 
-import { Datasource } from "../datasource";
-import { ProjectConfig } from "../config";
-
 import { getAttributeJoiSchema } from "./attributeSchema";
 import { getConditionsJoiSchema } from "./conditionSchema";
 import { getSegmentJoiSchema } from "./segmentSchema";
@@ -13,10 +10,12 @@ import { getTestsJoiSchema } from "./testSchema";
 
 import { checkForCircularDependencyInRequired } from "./checkCircularDependency";
 import { printJoiError } from "./printJoiError";
+import { Dependencies } from "../dependencies";
 
-export async function lintProject(projectConfig: ProjectConfig): Promise<boolean> {
+export async function lintProject(deps: Dependencies): Promise<boolean> {
+  const { projectConfig, datasource } = deps;
+
   let hasError = false;
-  const datasource = new Datasource(projectConfig);
 
   const availableAttributeKeys: string[] = [];
   const availableSegmentKeys: string[] = [];

--- a/packages/core/src/restore.ts
+++ b/packages/core/src/restore.ts
@@ -1,9 +1,11 @@
 import * as path from "path";
 import { execSync } from "child_process";
 
-import { ProjectConfig } from "./config";
+import { Dependencies } from "./dependencies";
 
-export async function restoreProject(rootDirectoryPath, projectConfig: ProjectConfig) {
+export async function restoreProject(deps: Dependencies) {
+  const { rootDirectoryPath, projectConfig } = deps;
+
   const relativeStateDirPath = path.relative(rootDirectoryPath, projectConfig.stateDirectoryPath);
   const cmd = `git checkout -- ${relativeStateDirPath}${path.sep}`;
 

--- a/packages/core/src/site/exportSite.ts
+++ b/packages/core/src/site/exportSite.ts
@@ -3,13 +3,14 @@ import * as path from "path";
 
 import * as mkdirp from "mkdirp";
 
-import { ProjectConfig } from "../config";
-
 import { generateHistory } from "./generateHistory";
 import { getRepoDetails } from "./getRepoDetails";
 import { generateSiteSearchIndex } from "./generateSiteSearchIndex";
+import { Dependencies } from "../dependencies";
 
-export async function exportSite(rootDirectoryPath: string, projectConfig: ProjectConfig) {
+export async function exportSite(deps: Dependencies) {
+  const { rootDirectoryPath, projectConfig } = deps;
+
   const hasError = false;
 
   mkdirp.sync(projectConfig.siteExportDirectoryPath);
@@ -30,12 +31,7 @@ export async function exportSite(rootDirectoryPath: string, projectConfig: Proje
 
   // site search index
   const repoDetails = getRepoDetails();
-  const searchIndex = await generateSiteSearchIndex(
-    rootDirectoryPath,
-    projectConfig,
-    fullHistory,
-    repoDetails,
-  );
+  const searchIndex = await generateSiteSearchIndex(deps, fullHistory, repoDetails);
   const searchIndexFilePath = path.join(projectConfig.siteExportDirectoryPath, "search-index.json");
   fs.writeFileSync(searchIndexFilePath, JSON.stringify(searchIndex));
   console.log(`Site search index written at: ${searchIndexFilePath}`);

--- a/packages/core/src/site/generateSiteSearchIndex.ts
+++ b/packages/core/src/site/generateSiteSearchIndex.ts
@@ -7,20 +7,20 @@ import {
   Condition,
 } from "@featurevisor/types";
 
-import { Datasource } from "../datasource";
-import { ProjectConfig } from "../config";
 import { extractAttributeKeysFromConditions, extractSegmentKeysFromGroupSegments } from "../utils";
 
 import { getRelativePaths } from "./getRelativePaths";
 import { getLastModifiedFromHistory } from "./getLastModifiedFromHistory";
 import { RepoDetails } from "./getRepoDetails";
+import { Dependencies } from "../dependencies";
 
 export async function generateSiteSearchIndex(
-  rootDirectoryPath: string,
-  projectConfig: ProjectConfig,
+  deps: Dependencies,
   fullHistory: HistoryEntry[],
   repoDetails: RepoDetails | undefined,
 ): Promise<SearchIndex> {
+  const { rootDirectoryPath, projectConfig, datasource } = deps;
+
   const result: SearchIndex = {
     links: undefined,
     entities: {
@@ -29,7 +29,6 @@ export async function generateSiteSearchIndex(
       features: [],
     },
   };
-  const datasource = new Datasource(projectConfig);
 
   /**
    * Links

--- a/packages/core/src/site/serveSite.ts
+++ b/packages/core/src/site/serveSite.ts
@@ -2,13 +2,11 @@ import * as fs from "fs";
 import * as path from "path";
 import * as http from "http";
 
-import { ProjectConfig } from "../config";
+import { Dependencies } from "../dependencies";
 
-export function serveSite(
-  rootDirectoryPath: string,
-  projectConfig: ProjectConfig,
-  options: any = {},
-) {
+export function serveSite(deps: Dependencies) {
+  const { projectConfig, options } = deps;
+
   const port = options.p || 3000;
 
   http

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -2,19 +2,15 @@ import * as fs from "fs";
 
 import { TestSegment, TestFeature } from "@featurevisor/types";
 
-import { ProjectConfig } from "../config";
-import { Datasource } from "../datasource";
-
 import { testSegment } from "./testSegment";
 import { testFeature } from "./testFeature";
 import { CLI_FORMAT_BOLD, CLI_FORMAT_GREEN, CLI_FORMAT_RED } from "./cliFormat";
+import { Dependencies } from "../dependencies";
 
-export async function testProject(
-  rootDirectoryPath: string,
-  projectConfig: ProjectConfig,
-): Promise<boolean> {
+export async function testProject(deps: Dependencies): Promise<boolean> {
+  const { rootDirectoryPath, projectConfig, datasource } = deps;
+
   let hasError = false;
-  const datasource = new Datasource(projectConfig);
 
   if (!fs.existsSync(projectConfig.testsDirectoryPath)) {
     console.error(`Tests directory does not exist: ${projectConfig.testsDirectoryPath}`);


### PR DESCRIPTION
## What's done

Dependencies like project config and datasource instance are injected from one place now (CLI runner).

This helps `core` package not have to deal with too many implementation details.

A continuation of #175 