### PR TITLE
feat: YAML includes support with example project

### DIFF
--- a/examples/example-yml-include/.gitignore
+++ b/examples/example-yml-include/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+*.log
+npm-debug.log*
+.DS_Store
+
+dist
+out
+src

--- a/examples/example-yml-include/README.md
+++ b/examples/example-yml-include/README.md
@@ -1,0 +1,59 @@
+# example-yml
+
+Basic example showing how Featurevisor works, with all definitions written in YAML and an example of how to include other YAML files.
+
+Visit [https://featurevisor.com](https://featurevisor.com) for more information.
+
+## Initialize
+
+```
+$ mkdir my-featurevisor-project
+$ cd my-featurevisor-project
+$ npx @featurevisor/cli init --example example-yml-include
+```
+
+## Installation
+
+```
+$ npm install
+```
+
+## Usage
+
+### Lint YAMLs
+
+```
+$ npm run lint
+```
+
+### Build datafiles
+
+```
+$ npm run build
+```
+
+### Test features
+
+```
+$ npm test
+```
+
+### Start local server
+
+Generates and serves status site:
+
+```
+$ npm start
+```
+
+### Generate code
+
+For additional type safety and autocompletion, you can generate TypeScript code from your YAMLs:
+
+```
+$ npm run generate-code
+```
+
+See output in `./src` directory.
+
+You may choose to publish the generated code as a private npm package and use it in multiple applications.

--- a/examples/example-yml-include/attributes/country.yml
+++ b/examples/example-yml-include/attributes/country.yml
@@ -1,0 +1,2 @@
+description: country code in lower case (two lettered)
+type: string

--- a/examples/example-yml-include/attributes/deviceId.yml
+++ b/examples/example-yml-include/attributes/deviceId.yml
@@ -1,0 +1,3 @@
+description: Device ID
+type: string
+capture: true

--- a/examples/example-yml-include/attributes/userId.yml
+++ b/examples/example-yml-include/attributes/userId.yml
@@ -1,0 +1,3 @@
+description: User ID
+type: string
+capture: true

--- a/examples/example-yml-include/features/rules/showCookieBanner-everyone.yml
+++ b/examples/example-yml-include/features/rules/showCookieBanner-everyone.yml
@@ -1,3 +1,3 @@
 - key: "everyone"
-  segments: "*" # everyone else
+  segments: "*"
   percentage: 0

--- a/examples/example-yml-include/features/rules/showCookieBanner-everyone.yml
+++ b/examples/example-yml-include/features/rules/showCookieBanner-everyone.yml
@@ -1,0 +1,3 @@
+- key: "everyone"
+  segments: "*" # everyone else
+  percentage: 0

--- a/examples/example-yml-include/features/rules/showCookieBanner-everyone.yml
+++ b/examples/example-yml-include/features/rules/showCookieBanner-everyone.yml
@@ -1,3 +1,3 @@
-- key: "everyone"
-  segments: "*"
-  percentage: 0
+key: "everyone"
+segments: "*"
+percentage: 0

--- a/examples/example-yml-include/features/rules/showCookieBanner-nl.yml
+++ b/examples/example-yml-include/features/rules/showCookieBanner-nl.yml
@@ -1,4 +1,4 @@
-- key: "nl"
-  segments:
-    - netherlands
-  percentage: 100
+key: "nl"
+segments:
+  - netherlands
+percentage: 100

--- a/examples/example-yml-include/features/rules/showCookieBanner-nl.yml
+++ b/examples/example-yml-include/features/rules/showCookieBanner-nl.yml
@@ -1,0 +1,4 @@
+- key: "nl"
+  segments:
+    - netherlands # enabled in prod for NL only
+  percentage: 100

--- a/examples/example-yml-include/features/rules/showCookieBanner-nl.yml
+++ b/examples/example-yml-include/features/rules/showCookieBanner-nl.yml
@@ -1,4 +1,4 @@
 - key: "nl"
   segments:
-    - netherlands # enabled in prod for NL only
+    - netherlands
   percentage: 100

--- a/examples/example-yml-include/features/showCookieBanner.yml
+++ b/examples/example-yml-include/features/showCookieBanner.yml
@@ -7,9 +7,9 @@ bucketBy: userId
 environments:
   staging:
     rules:
-      !include rules/showCookieBanner-everyone.yml
+      - !include rules/showCookieBanner-everyone.yml
 
   production:
     rules:
-      !include rules/showCookieBanner-nl.yml
-      !include rules/showCookieBanner-everyone.yml
+      - !include rules/showCookieBanner-nl.yml
+      - !include rules/showCookieBanner-everyone.yml

--- a/examples/example-yml-include/features/showCookieBanner.yml
+++ b/examples/example-yml-include/features/showCookieBanner.yml
@@ -1,0 +1,15 @@
+description: Show cookie banner to users from the Netherlands
+tags:
+  - all
+
+bucketBy: userId
+
+environments:
+  staging:
+    rules:
+      !include rules/showCookieBanner-everyone.yml
+
+  production:
+    rules:
+      !include rules/showCookieBanner-nl.yml
+      !include rules/showCookieBanner-everyone.yml

--- a/examples/example-yml-include/featurevisor.config.js
+++ b/examples/example-yml-include/featurevisor.config.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const path = require("path");
+const YAML = require("js-yaml");
+
+function includeLoader(content, filePath) {
+  const basePath = path.dirname(filePath);
+
+  const includeRegex = /^!include\s+(.+)$/gm;
+  let match;
+  while ((match = includeRegex.exec(content))) {
+    const includePath = match[1];
+    const includeFilePath = path.resolve(basePath, includePath);
+    const includeContent = fs.readFileSync(includeFilePath, "utf8");
+    content = content.replace(match[0], includeContent);
+  }
+
+  // Parse the modified YAML content.
+  return YAML.load(content);
+}
+
+module.exports = {
+  environments: ["staging", "production"],
+  tags: ["all"],
+  prettyState: true,
+  parser: {
+    extension: "yml",
+    parse: function (content, filePath) {
+      return includeLoader(content, filePath);
+    },
+  },
+};

--- a/examples/example-yml-include/package.json
+++ b/examples/example-yml-include/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@featurevisor/example-yml-include",
+  "private": true,
+  "version": "0.54.0",
+  "description": "Featurevisor project with YAML definitions and custom includes",
+  "scripts": {
+    "lint": "featurevisor lint",
+    "build": "featurevisor build",
+    "test": "featurevisor test",
+    "export": "featurevisor site export",
+    "start": "npm run export && featurevisor site serve",
+    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src",
+    "find-duplicate-segments": "featurevisor find-duplicate-segments"
+  },
+  "dependencies": {
+    "@featurevisor/cli": "^0.54.0"
+  }
+}

--- a/examples/example-yml-include/segments/netherlands.yml
+++ b/examples/example-yml-include/segments/netherlands.yml
@@ -1,0 +1,5 @@
+description: The Netherlands
+conditions:
+  - attribute: country
+    operator: equals
+    value: nl

--- a/examples/example-yml-include/tests/netherlands.segment.yml
+++ b/examples/example-yml-include/tests/netherlands.segment.yml
@@ -1,0 +1,14 @@
+segment: netherlands
+assertions:
+  - context:
+      country: nl
+    expectedToMatch: true
+
+  - context:
+      country: de
+      someOtherAttribute: someOtherValue
+    expectedToMatch: false
+
+  - context:
+      country: notNl
+    expectedToMatch: false

--- a/examples/example-yml-include/tests/showCookieBanner.feature.yml
+++ b/examples/example-yml-include/tests/showCookieBanner.feature.yml
@@ -1,0 +1,29 @@
+feature: showCookieBanner
+assertions:
+  - at: 10
+    description: "At 10%, the feature should be enabled for NL"
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+
+  - at: 70
+    description: "At 70%, the feature should be enabled for NL"
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+
+  - at: 90
+    description: "At 90%, the feature should be disabled for US"
+    environment: production
+    context:
+      country: us
+    expectedToBeEnabled: false
+
+  - at: 90
+    description: "At 90%, the feature should be disabled for Canada"
+    environment: production
+    context:
+      country: ca
+    expectedToBeEnabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,12 @@
         "@featurevisor/cli": "^0.54.0"
       }
     },
+    "examples/example-yml-include": {
+      "version": "0.54.0",
+      "dependencies": {
+        "@featurevisor/cli": "^0.54.0"
+      }
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -818,6 +824,10 @@
     },
     "node_modules/@featurevisor/example-yml": {
       "resolved": "examples/example-yml",
+      "link": true
+    },
+    "node_modules/@featurevisor/example-yml-include": {
+      "resolved": "examples/example-yml-include",
       "link": true
     },
     "node_modules/@featurevisor/react": {

--- a/packages/core/src/config/parsers.ts
+++ b/packages/core/src/config/parsers.ts
@@ -33,7 +33,7 @@ export type BuiltInParser = keyof typeof parsers; // keys of parsers object
 
 export interface CustomParser {
   extension: string;
-  parse: <T>(content: string) => T;
+  parse: <T>(content: string, filePath?: string) => T;
   stringify: (content: any) => string;
 }
 

--- a/packages/core/src/datasource/filesystemAdapter.ts
+++ b/packages/core/src/datasource/filesystemAdapter.ts
@@ -70,9 +70,10 @@ export class FilesystemAdapter extends Adapter {
   }
 
   async parseEntity<T>(entityType: EntityType, entityKey: string): Promise<T> {
-    const entityContent = await this.readEntity(entityType, entityKey);
+    const filePath = this.getEntityPath(entityType, entityKey);
+    const entityContent = fs.readFileSync(filePath, "utf8");
 
-    return this.parser.parse<T>(entityContent);
+    return this.parser.parse<T>(entityContent, filePath);
   }
 
   /**


### PR DESCRIPTION
## What's done

It is possible that a certain feature definition can grow really large, especially with too many rules against its multiple environments.

This PR makes a small change in custom parser API to pass `filePath`, if using filesystem adapter.

And from individual Featurevisor project's config level, we can expand the YAML parser with `!include` tag for including YAML content from other files, thus breaking a large file into smaller ones.

## Example project

See more in the branch's [`examples/example-yml-include`](https://github.com/featurevisor/featurevisor/tree/yml-include/examples/example-yml-include) directory.

## Comparison

### Before

```yml
# features/showCookieBanner.yml
description: Show cookie banner to users from the Netherlands
tags:
  - all

bucketBy: userId

environments:
  staging:
    rules:
      - key: "everyone"
        segments: "*" # enabled for everyone in staging only
        percentage: 100

  production:
    rules:
      - key: "nl"
        segments:
          - netherlands # enabled in production for NL only
        percentage: 100

      - key: "everyone"
        segments: "*" # everyone else in production
        percentage: 0
```

### After

```yml
# features/showCookieBanner.yml
description: Show cookie banner to users from the Netherlands
tags:
  - all

bucketBy: userId

environments:
  staging:
    rules:
      - !include rules/showCookieBanner-everyone.yml

  production:
    rules:
      - !include rules/showCookieBanner-nl.yml
      - !include rules/showCookieBanner-everyone-disabled.yml
```

With the rules coming from:

```yml
# features/rules/showCookieBanner-nl.yml
key: "nl"
segments:
  - netherlands
percentage: 100
```

## Impact

The impact on core libraries of Featurevisor stays minimal, and they have no knowledge of expanding custom parser with `!include` functionality at all.

This kind of extra logic stays fully at your own Featurevisor project level's [`featurevisor.config.js`](https://github.com/featurevisor/featurevisor/blob/yml-include/examples/example-yml-include/featurevisor.config.js).