### PR TITLE
chore: move datafile writing to datasource level

### DIFF
--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -1,24 +1,9 @@
-import * as fs from "fs";
 import * as path from "path";
 
-import * as mkdirp from "mkdirp";
-
-import { ExistingState, EnvironmentKey } from "@featurevisor/types";
-
-import { SCHEMA_VERSION, ProjectConfig } from "../config";
+import { SCHEMA_VERSION } from "../config";
 
 import { buildDatafile } from "./buildDatafile";
 import { Dependencies } from "../dependencies";
-
-export function getDatafilePath(
-  projectConfig: ProjectConfig,
-  environment: EnvironmentKey,
-  tag: string,
-): string {
-  const fileName = `datafile-tag-${tag}.json`;
-
-  return path.join(projectConfig.outputDirectoryPath, environment, fileName);
-}
 
 export interface BuildCLIOptions {
   revision?: string;
@@ -35,10 +20,11 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
   for (const environment of environments) {
     console.log(`\nBuilding datafiles for environment: ${environment}`);
 
-    const existingState: ExistingState = await datasource.readState(environment);
+    const existingState = await datasource.readState(environment);
 
     for (const tag of tags) {
       console.log(`\n  => Tag: ${tag}`);
+
       const datafileContent = await buildDatafile(
         projectConfig,
         datasource,
@@ -52,18 +38,10 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
       );
 
       // write datafile for environment/tag
-      const outputEnvironmentDirPath = path.join(projectConfig.outputDirectoryPath, environment);
-      mkdirp.sync(outputEnvironmentDirPath);
-
-      const outputFilePath = getDatafilePath(projectConfig, environment, tag);
-      fs.writeFileSync(
-        outputFilePath,
-        projectConfig.prettyDatafile
-          ? JSON.stringify(datafileContent, null, 2)
-          : JSON.stringify(datafileContent),
-      );
-      const shortPath = outputFilePath.replace(rootDirectoryPath + path.sep, "");
-      console.log(`     Datafile generated: ${shortPath}`);
+      await datasource.writeDatafile(datafileContent, {
+        environment,
+        tag,
+      });
     }
 
     // write state for environment

--- a/packages/core/src/datasource/adapter.ts
+++ b/packages/core/src/datasource/adapter.ts
@@ -1,6 +1,11 @@
-import { EnvironmentKey, ExistingState } from "@featurevisor/types";
+import { DatafileContent, EnvironmentKey, ExistingState } from "@featurevisor/types";
 
 export type EntityType = "feature" | "group" | "segment" | "attribute" | "test";
+
+export interface DatafileOptions {
+  environment: EnvironmentKey;
+  tag: string;
+}
 
 export abstract class Adapter {
   // entities
@@ -12,4 +17,8 @@ export abstract class Adapter {
   // state
   abstract readState(environment: EnvironmentKey): Promise<ExistingState>;
   abstract writeState(environment: EnvironmentKey, existingState: ExistingState): Promise<void>;
+
+  // datafile
+  abstract readDatafile(options: DatafileOptions): Promise<DatafileContent>;
+  abstract writeDatafile(datafileContent: DatafileContent, options: DatafileOptions): Promise<void>;
 }

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -9,11 +9,12 @@ import {
   ExistingState,
   SegmentKey,
   AttributeKey,
+  DatafileContent,
 } from "@featurevisor/types";
 
 import { ProjectConfig, CustomParser } from "../config";
 
-import { Adapter } from "./adapter";
+import { Adapter, DatafileOptions } from "./adapter";
 
 export class Datasource {
   private adapter: Adapter;
@@ -30,12 +31,23 @@ export class Datasource {
   /**
    * State
    */
-  async readState(environment: EnvironmentKey): Promise<ExistingState> {
+  readState(environment: EnvironmentKey): Promise<ExistingState> {
     return this.adapter.readState(environment);
   }
 
-  async writeState(environment: EnvironmentKey, existingState: ExistingState) {
+  writeState(environment: EnvironmentKey, existingState: ExistingState) {
     return this.adapter.writeState(environment, existingState);
+  }
+
+  /**
+   * Datafile
+   */
+  readDatafile(options: DatafileOptions) {
+    return this.adapter.readDatafile(options);
+  }
+
+  writeDatafile(datafileContent: DatafileContent, options: DatafileOptions) {
+    return this.adapter.writeDatafile(datafileContent, options);
   }
 
   /**
@@ -43,8 +55,8 @@ export class Datasource {
    */
 
   // features
-  async listFeatures() {
-    return await this.adapter.listEntities("feature");
+  listFeatures() {
+    return this.adapter.listEntities("feature");
   }
 
   featureExists(featureKey: FeatureKey) {
@@ -111,7 +123,7 @@ export class Datasource {
   }
 
   // groups
-  async listGroups() {
+  listGroups() {
     return this.adapter.listEntities("group");
   }
 


### PR DESCRIPTION
## What's done

The responsibilities of writing datafiles to disk has been moved to Datasource adapter level, leaving CLI runners simple even if internal implementations change in future.

See the impact of this change in `buildProject.ts` file.