### PR TITLE
fix: return proper variable values when toggle has no allocations

### DIFF
--- a/examples/example-1/features/fooNoVariations.yml
+++ b/examples/example-1/features/fooNoVariations.yml
@@ -1,0 +1,40 @@
+archived: false
+description: blah
+tags:
+  - all
+  - sign-in
+  - sign-up
+
+bucketBy: userId
+
+variablesSchema:
+  - key: bar
+    type: string
+    defaultValue: ""
+  - key: baz
+    type: string
+    defaultValue: ""
+
+environments:
+  staging:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 100
+        variables:
+          bar: "bar_here"
+  production:
+    rules:
+      - key: "1"
+        segments:
+          and:
+            - mobile
+            - or:
+                - germany
+                - switzerland
+        percentage: 80
+        variables:
+          baz: "baz_here"
+      - key: "2"
+        segments: "*"
+        percentage: 50

--- a/examples/example-1/tests/fooNoVariations.spec.yml
+++ b/examples/example-1/tests/fooNoVariations.spec.yml
@@ -1,0 +1,39 @@
+feature: fooNoVariations
+assertions:
+  - at: 40
+    environment: staging
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariables:
+      bar: bar_here
+      baz: ""
+
+  - at: 60
+    environment: staging
+    context:
+      country: ch
+    expectedToBeEnabled: true
+    expectedVariables:
+      bar: bar_here
+      baz: ""
+
+  - at: 70
+    environment: production
+    context:
+      country: de
+      device: mobile
+    expectedToBeEnabled: true
+    expectedVariables:
+      bar: ""
+      baz: baz_here
+
+  - at: 40
+    environment: production
+    context:
+      country: it
+      device: desktop
+    expectedToBeEnabled: true
+    expectedVariables:
+      bar: ""
+      baz: ""

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -55,25 +55,33 @@ export function getMatchedTrafficAndAllocation(
 ): MatchedTrafficAndAllocation {
   let matchedAllocation: Allocation | undefined;
 
-  const matchedTraffic = traffic.find((t) => {
-    if (
-      !allGroupSegmentsAreMatched(parseFromStringifiedSegments(t.segments), context, datafileReader)
-    ) {
-      return false;
-    }
+  const matchedTraffics = traffic.filter((t) =>
+    allGroupSegmentsAreMatched(parseFromStringifiedSegments(t.segments), context, datafileReader),
+  );
 
+  if (!matchedTraffics.length) {
+    return {
+      matchedTraffic: undefined,
+      matchedAllocation: undefined,
+    };
+  }
+
+  const matchedTraffic = matchedTraffics.find((t) => {
     matchedAllocation = getMatchedAllocation(t, bucketValue);
 
-    if (matchedAllocation) {
-      return true;
-    }
-
-    return false;
+    return !!matchedAllocation;
   });
 
+  if (matchedTraffic && matchedAllocation) {
+    return {
+      matchedTraffic,
+      matchedAllocation,
+    };
+  }
+
   return {
-    matchedTraffic,
-    matchedAllocation,
+    matchedTraffic: matchedTraffics[0],
+    matchedAllocation: undefined,
   };
 }
 

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -1104,6 +1104,35 @@ describe("sdk: instance", function () {
               },
             ],
           },
+          {
+            key: "test2",
+            bucketBy: "userId",
+            variablesSchema: [
+              {
+                key: "color",
+                type: "string",
+                defaultValue: "red",
+              },
+            ],
+            variations: [],
+            traffic: [
+              {
+                key: "1",
+                segments: ["belgium"],
+                percentage: 100000,
+                allocation: [],
+                variables: {
+                  color: "black",
+                },
+              },
+              {
+                key: "2",
+                segments: ["netherlands"],
+                percentage: 100000,
+                allocation: [],
+              },
+            ],
+          },
         ],
         attributes: [
           { key: "userId", type: "string", capture: true },
@@ -1203,6 +1232,20 @@ describe("sdk: instance", function () {
 
     // disabled
     expect(sdk.getVariable("test", "color", { userId: "user-gb" })).toEqual(undefined);
+
+    // no variations
+    expect(
+      sdk.getVariable("test2", "color", {
+        ...context,
+        country: "be",
+      }),
+    ).toEqual("black");
+    expect(
+      sdk.getVariable("test2", "color", {
+        ...context,
+        country: "nl",
+      }),
+    ).toEqual("red");
   });
 
   it("should check if enabled for individually named segments", function () {


### PR DESCRIPTION
Variable values assigned in the feature rules were only returned if feature had variations configured. This PR is fixing that issue and returns first matched rule if there are no rules that are matching variation allocations.

In case the feature had no variations defined variable values had always default values from variables schema.