### PR TITLE
feat: add deep linking, persist search in url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14786,9 +14786,10 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14786,10 +14786,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "version": "6.0.11",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"

--- a/packages/site/src/components/HistoryTimeline.tsx
+++ b/packages/site/src/components/HistoryTimeline.tsx
@@ -4,7 +4,7 @@ import { UserCircleIcon } from "@heroicons/react/20/solid";
 
 import { Alert } from "./Alert";
 import { PrettyDate } from "./PrettyDate";
-import { useSearchIndex } from "../hooks/searchIndexHook";
+import { useSearchIndex } from "../hooks/useSearchIndex";
 
 const entriesPerPage = 50;
 const initialMaxEntitiesCount = 10;

--- a/packages/site/src/components/ListAttributes.tsx
+++ b/packages/site/src/components/ListAttributes.tsx
@@ -1,30 +1,22 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 
-import { SearchIndex } from "@featurevisor/types";
-import { useSearchIndex } from "../hooks/searchIndexHook";
-import { getQueryFromString, getAttributesByQuery } from "../utils";
 import { Tag } from "./Tag";
 import { Alert } from "./Alert";
 import { SearchInput } from "./SearchInput";
 import { PageTitle } from "./PageTitle";
 import { PageContent } from "./PageContent";
 import { LastModified } from "./LastModified";
+import { useSearch } from "../hooks/useSearch";
 
 export function ListAttributes() {
-  const [q, setQ] = React.useState("");
-
-  const contextValue = useSearchIndex();
-  const data = contextValue.data as SearchIndex;
-
-  const query = getQueryFromString(q);
-  const attributes = getAttributesByQuery(query, data);
+  const { attributes } = useSearch();
 
   return (
     <PageContent>
       <PageTitle>Attributes</PageTitle>
 
-      <SearchInput value={q} onChange={(e: any) => setQ(e.target.value)} />
+      <SearchInput />
 
       {attributes.length === 0 && <Alert type="warning">No results found</Alert>}
 

--- a/packages/site/src/components/ListFeatures.tsx
+++ b/packages/site/src/components/ListFeatures.tsx
@@ -3,9 +3,6 @@ import { Link } from "react-router-dom";
 
 import { TagIcon } from "@heroicons/react/20/solid";
 
-import { SearchIndex } from "@featurevisor/types";
-import { useSearchIndex } from "../hooks/searchIndexHook";
-import { getQueryFromString, getFeaturesByQuery } from "../utils";
 import { EnvironmentDot } from "./EnvironmentDot";
 import { Tag } from "./Tag";
 import { Alert } from "./Alert";
@@ -13,21 +10,16 @@ import { SearchInput } from "./SearchInput";
 import { PageTitle } from "./PageTitle";
 import { PageContent } from "./PageContent";
 import { LastModified } from "./LastModified";
+import { useSearch } from "../hooks/useSearch";
 
 export function ListFeatures() {
-  const [q, setQ] = React.useState("");
-
-  const contextValue = useSearchIndex();
-  const data = contextValue.data as SearchIndex;
-
-  const query = getQueryFromString(q);
-  const features = getFeaturesByQuery(query, data);
+  const { features } = useSearch();
 
   return (
     <PageContent>
       <PageTitle>Features</PageTitle>
 
-      <SearchInput value={q} onChange={(e: any) => setQ(e.target.value)} />
+      <SearchInput />
 
       {features.length === 0 && <Alert type="warning">No results found</Alert>}
 

--- a/packages/site/src/components/ListSegments.tsx
+++ b/packages/site/src/components/ListSegments.tsx
@@ -1,30 +1,22 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 
-import { SearchIndex } from "@featurevisor/types";
-import { useSearchIndex } from "../hooks/searchIndexHook";
-import { getQueryFromString, getSegmentsByQuery } from "../utils";
 import { Tag } from "./Tag";
 import { Alert } from "./Alert";
 import { SearchInput } from "./SearchInput";
 import { PageTitle } from "./PageTitle";
 import { PageContent } from "./PageContent";
 import { LastModified } from "./LastModified";
+import { useSearch } from "../hooks/useSearch";
 
 export function ListSegments() {
-  const [q, setQ] = React.useState("");
-
-  const contextValue = useSearchIndex();
-  const data = contextValue.data as SearchIndex;
-
-  const query = getQueryFromString(q);
-  const segments = getSegmentsByQuery(query, data);
+  const { segments } = useSearch();
 
   return (
     <PageContent>
       <PageTitle>Segments</PageTitle>
 
-      <SearchInput value={q} onChange={(e: any) => setQ(e.target.value)} />
+      <SearchInput />
 
       {segments.length === 0 && <Alert type="warning">No results found</Alert>}
 

--- a/packages/site/src/components/SearchInput.tsx
+++ b/packages/site/src/components/SearchInput.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
+import { useSearch } from "../hooks/useSearch";
 
-interface SearchInputProps {
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}
+export function SearchInput() {
+  const { searchQuery, setSearchQuery } = useSearch();
 
-export function SearchInput(props: SearchInputProps) {
   return (
     <div className="relative px-6 pt-3.5">
       <div className="pointer-events-none absolute">
@@ -23,8 +21,8 @@ export function SearchInput(props: SearchInputProps) {
       </div>
       <input
         type="text"
-        value={props.value}
-        onChange={(e) => props.onChange(e)}
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
         placeholder="Type to search..."
         autoComplete="off"
         className="mb-4 mt-2 p-2 w-full rounded-full border border-slate-300 indent-8 text-xl text-gray-700 placeholder:text-gray-400"

--- a/packages/site/src/components/ShowAttribute.tsx
+++ b/packages/site/src/components/ShowAttribute.tsx
@@ -5,7 +5,7 @@ import { PageContent } from "./PageContent";
 import { PageTitle } from "./PageTitle";
 import { Tabs } from "./Tabs";
 import { EditLink } from "./EditLink";
-import { useSearchIndex } from "../hooks/searchIndexHook";
+import { useSearchIndex } from "../hooks/useSearchIndex";
 import { Markdown } from "./Markdown";
 import { HistoryTimeline } from "./HistoryTimeline";
 

--- a/packages/site/src/components/ShowFeature.tsx
+++ b/packages/site/src/components/ShowFeature.tsx
@@ -6,7 +6,7 @@ import { PageTitle } from "./PageTitle";
 import { Tabs } from "./Tabs";
 import { HistoryTimeline } from "./HistoryTimeline";
 import { Tag } from "./Tag";
-import { useSearchIndex } from "../hooks/searchIndexHook";
+import { useSearchIndex } from "../hooks/useSearchIndex";
 import { isEnabledInEnvironment } from "../utils";
 import { ExpandRuleSegments } from "./ExpandRuleSegments";
 import { ExpandConditions } from "./ExpandConditions";

--- a/packages/site/src/components/ShowSegment.tsx
+++ b/packages/site/src/components/ShowSegment.tsx
@@ -7,7 +7,7 @@ import { Tabs } from "./Tabs";
 import { HistoryTimeline } from "./HistoryTimeline";
 import { ExpandConditions } from "./ExpandConditions";
 import { EditLink } from "./EditLink";
-import { useSearchIndex } from "../hooks/searchIndexHook";
+import { useSearchIndex } from "../hooks/useSearchIndex";
 import { Markdown } from "./Markdown";
 
 export function DisplaySegmentOverview() {

--- a/packages/site/src/hooks/searchIndexHook.ts
+++ b/packages/site/src/hooks/searchIndexHook.ts
@@ -1,9 +1,0 @@
-import { useContext } from "react";
-
-import { SearchIndexContext } from "../contexts/SearchIndexContext";
-
-export function useSearchIndex() {
-  const value = useContext(SearchIndexContext);
-
-  return value;
-}

--- a/packages/site/src/hooks/useSearch.ts
+++ b/packages/site/src/hooks/useSearch.ts
@@ -1,0 +1,41 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import { useSearchIndex } from "./useSearchIndex";
+import {
+  parseSearchQuery,
+  getFeaturesByQuery,
+  getAttributesByQuery,
+  getSegmentsByQuery,
+} from "../utils";
+
+const SEARCH_QUERY_KEY = "q";
+
+export function useSearch() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchQuery = String(searchParams.get(SEARCH_QUERY_KEY) || "");
+
+  const { data: searchData } = useSearchIndex();
+  const parsedQuery = parseSearchQuery(searchQuery);
+  const features = getFeaturesByQuery(parsedQuery, searchData);
+  const segments = getSegmentsByQuery(parsedQuery, searchData);
+  const attributes = getAttributesByQuery(parsedQuery, searchData);
+
+  const setSearchQuery = useCallback((value) => {
+    const newSearchParams = new URLSearchParams(searchParams.toString());
+    if (value) {
+      newSearchParams.set(SEARCH_QUERY_KEY, String(value));
+    } else {
+      newSearchParams.delete(SEARCH_QUERY_KEY);
+    }
+    setSearchParams(newSearchParams);
+  }, []);
+
+  return {
+    searchQuery,
+    features,
+    segments,
+    attributes,
+    setSearchQuery,
+  } as const;
+}

--- a/packages/site/src/hooks/useSearchIndex.ts
+++ b/packages/site/src/hooks/useSearchIndex.ts
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { SearchIndex } from "@featurevisor/types";
+
+import { SearchIndexContext } from "../contexts/SearchIndexContext";
+
+export function useSearchIndex() {
+  const { data } = useContext(SearchIndexContext);
+
+  return {
+    data: data as SearchIndex,
+  };
+}

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -8,7 +8,7 @@ export interface Query {
   capture?: boolean;
 }
 
-export function getQueryFromString(q: string) {
+export function parseSearchQuery(queryString: string) {
   const query: Query = {
     keyword: "",
     tags: [],
@@ -17,7 +17,7 @@ export function getQueryFromString(q: string) {
     capture: undefined,
   };
 
-  const parts = q.split(" ");
+  const parts = queryString.split(" ");
 
   for (const part of parts) {
     if (part.startsWith("tag:")) {


### PR DESCRIPTION
We want to be able to share the url and deeplink to the page shared. For that purpose we need to persist the search params in the url. Read the url, extract the search query and load the correct view.

**Changes:**
* Add `useSearch` hook responsible for:
   * read/write search params from the url
   * parse url query to query object
   * generate features, segments, attributes based on parsed query object
* `SearchInput` component sets the search input to the url (through `useSearch` hook)
* Features, Segments, Attributes views read the respective data from `useSearch` hook

**Preview:**

https://github.com/featurevisor/featurevisor/assets/1969742/f2610257-ad28-449b-96fe-dbc65007d7e6

https://github.com/featurevisor/featurevisor/issues/36