### PR TITLE
fix: evaluate variables overridden from rules with no variations

### DIFF
--- a/examples/example-1/features/checkout.yml
+++ b/examples/example-1/features/checkout.yml
@@ -7,23 +7,24 @@ bucketBy: userId
 variablesSchema:
   - key: showPayments
     type: boolean
-    default: false
+    defaultValue: false
 
   - key: showShipping
     type: boolean
-    default: false
+    defaultValue: false
 
   - key: paymentMethods
     type: array
-    default:
+    defaultValue:
       - visa
       - mastercard
 
 environments:
   staging:
-    - key: "1"
-      segments: "*"
-      percentage: 100
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 100
 
   production:
     rules:

--- a/examples/example-1/features/checkout.yml
+++ b/examples/example-1/features/checkout.yml
@@ -1,0 +1,55 @@
+description: Testing variables without having any variations
+tags:
+  - all
+
+bucketBy: userId
+
+variablesSchema:
+  - key: showPayments
+    type: boolean
+    default: false
+
+  - key: showShipping
+    type: boolean
+    default: false
+
+  - key: paymentMethods
+    type: array
+    default:
+      - visa
+      - mastercard
+
+environments:
+  staging:
+    - key: "1"
+      segments: "*"
+      percentage: 100
+
+  production:
+    rules:
+      - key: "1"
+        segments: netherlands
+        percentage: 100
+        variables:
+          paymentMethods:
+            - ideal
+            - paypal
+
+      - key: "2"
+        segments: germany
+        percentage: 100
+        variables:
+          paymentMethods: true
+            - sofort
+            - paypal
+
+      - key: "3"
+        segments: "*"
+        percentage: 100
+        variables:
+          showPayments: true
+          showShipping: true
+          paymentMethods: true
+            - visa
+            - mastercard
+            - paypal

--- a/examples/example-1/features/checkout.yml
+++ b/examples/example-1/features/checkout.yml
@@ -39,7 +39,7 @@ environments:
         segments: germany
         percentage: 100
         variables:
-          paymentMethods: true
+          paymentMethods:
             - sofort
             - paypal
 
@@ -49,7 +49,7 @@ environments:
         variables:
           showPayments: true
           showShipping: true
-          paymentMethods: true
+          paymentMethods:
             - visa
             - mastercard
             - paypal

--- a/examples/example-1/tests/checkout.spec.yml
+++ b/examples/example-1/tests/checkout.spec.yml
@@ -1,13 +1,47 @@
 feature: checkout
 assertions:
+  ##
+  # Everyone
+  #
   - at: 60
     environment: production
     context:
       country: us
     expectedToBeEnabled: true
     expectedVariables:
-      showPayments: false
-      showShipping: false
+      showPayments: true
+      showShipping: true
       paymentMethods:
         - visa
         - mastercard
+        - paypal
+
+  ##
+  # NL
+  #
+  - at: 60
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: true
+    expectedVariables:
+      showPayments: false
+      showShipping: false
+      paymentMethods:
+        - ideal
+        - paypal
+
+  ##
+  # DE
+  #
+  - at: 80
+    environment: production
+    context:
+      country: de
+    expectedToBeEnabled: true
+    expectedVariables:
+      showPayments: false
+      showShipping: false
+      paymentMethods:
+        - sofort
+        - paypal

--- a/examples/example-1/tests/checkout.spec.yml
+++ b/examples/example-1/tests/checkout.spec.yml
@@ -1,0 +1,13 @@
+feature: checkout
+assertions:
+  - at: 60
+    environment: production
+    context:
+      country: us
+    expectedToBeEnabled: true
+    expectedVariables:
+      showPayments: false
+      showShipping: false
+      paymentMethods:
+        - visa
+        - mastercard

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -53,23 +53,22 @@ export function getMatchedTrafficAndAllocation(
   bucketValue: number,
   datafileReader: DatafileReader,
 ): MatchedTrafficAndAllocation {
-  let matchedAllocation: Allocation | undefined;
-
   const matchedTraffic = traffic.find((t) => {
-    if (
-      !allGroupSegmentsAreMatched(parseFromStringifiedSegments(t.segments), context, datafileReader)
-    ) {
-      return false;
-    }
-
-    matchedAllocation = getMatchedAllocation(t, bucketValue);
-
-    if (matchedAllocation) {
-      return true;
-    }
-
-    return false;
+    return allGroupSegmentsAreMatched(
+      parseFromStringifiedSegments(t.segments),
+      context,
+      datafileReader,
+    );
   });
+
+  if (!matchedTraffic) {
+    return {
+      matchedTraffic: undefined,
+      matchedAllocation: undefined,
+    };
+  }
+
+  const matchedAllocation = getMatchedAllocation(matchedTraffic, bucketValue);
 
   return {
     matchedTraffic,

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -1205,6 +1205,80 @@ describe("sdk: instance", function () {
     expect(sdk.getVariable("test", "color", { userId: "user-gb" })).toEqual(undefined);
   });
 
+  it("should get variables without any variations", function () {
+    const sdk = createInstance({
+      datafile: {
+        schemaVersion: "1",
+        revision: "1.0",
+        attributes: [
+          { key: "userId", type: "string", capture: true },
+          { key: "country", type: "string" },
+        ],
+        segments: [
+          {
+            key: "netherlands",
+            conditions: JSON.stringify([
+              {
+                attribute: "country",
+                operator: "equals",
+                value: "nl",
+              },
+            ]),
+          },
+        ],
+        features: [
+          {
+            key: "test",
+            bucketBy: "userId",
+            variablesSchema: [
+              {
+                key: "color",
+                type: "string",
+                defaultValue: "red",
+              },
+            ],
+            traffic: [
+              {
+                key: "1",
+                segments: "netherlands",
+                percentage: 100000,
+                variables: {
+                  color: "orange",
+                },
+                allocation: [],
+              },
+              {
+                key: "2",
+                segments: "*",
+                percentage: 100000,
+                allocation: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const defaultContext = {
+      userId: "123",
+    };
+
+    // test default value
+    expect(
+      sdk.getVariable("test", "color", {
+        ...defaultContext,
+      }),
+    ).toEqual("red");
+
+    // test override
+    expect(
+      sdk.getVariable("test", "color", {
+        ...defaultContext,
+        country: "nl",
+      }),
+    ).toEqual("orange");
+  });
+
   it("should check if enabled for individually named segments", function () {
     const sdk = createInstance({
       datafile: {


### PR DESCRIPTION
## What was the bug

When matching both the `Traffic` (rule equivalent in generated datafiles) and their `Allocation`, it used to always check if an `Allocation` is found or not in the Traffic itself.

This was problematic because not all features have variations.

Resulting into issues when evaluating variables (in features with no variations) which have overrides from rule level, because SDK never found any allocation info for them (since they had no variations).

## What was done to solve it

When matching both Traffic and Allocation, it will return:

- `Traffic` if segments matched (irrespective of Allocation bucket range checks), and
- `Allocation` if bucket range checks are satisfied

Tests are available in both YAML specs in example project, and also unit tests at SDK level.

Big thanks to @pawdat for his investigation in #187, wouldn't be possible otherwise.