### PR TITLE
fix: last modified info in generated site

### DIFF
--- a/packages/core/src/site/exportSite.ts
+++ b/packages/core/src/site/exportSite.ts
@@ -9,7 +9,7 @@ import { generateSiteSearchIndex } from "./generateSiteSearchIndex";
 import { Dependencies } from "../dependencies";
 
 export async function exportSite(deps: Dependencies) {
-  const { rootDirectoryPath, projectConfig } = deps;
+  const { projectConfig } = deps;
 
   const hasError = false;
 
@@ -24,7 +24,7 @@ export async function exportSite(deps: Dependencies) {
   console.log("Site dist copied to:", projectConfig.siteExportDirectoryPath);
 
   // generate history
-  const fullHistory = generateHistory(rootDirectoryPath, projectConfig);
+  const fullHistory = generateHistory(deps);
 
   // site search index
   const repoDetails = getRepoDetails();

--- a/packages/core/src/site/generateHistory.ts
+++ b/packages/core/src/site/generateHistory.ts
@@ -4,11 +4,12 @@ import { execSync } from "child_process";
 
 import { HistoryEntry } from "@featurevisor/types";
 
-import { ProjectConfig } from "../config";
-
 import { getRelativePaths } from "./getRelativePaths";
+import { Dependencies } from "../dependencies";
 
-export function generateHistory(rootDirectoryPath, projectConfig: ProjectConfig): HistoryEntry[] {
+export function generateHistory(deps: Dependencies): HistoryEntry[] {
+  const { rootDirectoryPath, projectConfig, datasource } = deps;
+
   try {
     // raw history
     const rawHistoryFilePath = path.join(projectConfig.siteExportDirectoryPath, "history-raw.txt");
@@ -66,7 +67,7 @@ export function generateHistory(rootDirectoryPath, projectConfig: ProjectConfig)
         const fileName = lineSplit.pop() as string;
         const relativeDir = lineSplit.join(path.sep);
 
-        const key = fileName.replace("." + projectConfig.parser, "");
+        const key = fileName.replace("." + datasource.getExtension(), "");
 
         let type = "feature" as "attribute" | "segment" | "feature";
 

--- a/packages/core/src/site/generateSiteSearchIndex.ts
+++ b/packages/core/src/site/generateSiteSearchIndex.ts
@@ -77,6 +77,7 @@ export async function generateSiteSearchIndex(
 
   // features
   const featureFiles = await datasource.listFeatures();
+
   for (const entityName of featureFiles) {
     const parsed = await datasource.readFeature(entityName);
 


### PR DESCRIPTION
## Issue

We used to show `n/a` in place of `Last modified` section in list view of generated site: https://featurevisor.com/docs/site/

This issue was likely introduced when introducing #158.

## Preview

<img width="1103" alt="Screenshot 2023-10-25 at 23 09 56" src="https://github.com/featurevisor/featurevisor/assets/20046/f1094dbc-8ff3-4ac9-a405-ea29381c4cc6">
