### PR TITLE
feat: small site navigation improvements

### DIFF
--- a/packages/site/src/components/App.tsx
+++ b/packages/site/src/components/App.tsx
@@ -72,11 +72,11 @@ export function App() {
                   <Route path="variables" element={<DisplayFeatureVariablesSchema />} />
                   <Route path="rules" element={<DisplayFeatureRules />}>
                     <Route path=":environmentKey" element={<DisplayFeatureRulesTable />} />
-                    <Route index element={<Navigate to={environmentKeys[0]} replace/>} />
+                    <Route index element={<Navigate to={environmentKeys[0]} replace />} />
                   </Route>
                   <Route path="force" element={<DisplayFeatureForce />}>
                     <Route path=":environmentKey" element={<DisplayFeatureForceTable />} />
-                    <Route index element={<Navigate to={environmentKeys[0]} replace/>} />
+                    <Route index element={<Navigate to={environmentKeys[0]} replace />} />
                   </Route>
                   <Route path="history" element={<DisplayFeatureHistory />} />
                 </Route>
@@ -103,7 +103,7 @@ export function App() {
               </Route>
 
               <Route path="history" element={<ListHistory />} />
-              <Route index element={<Navigate to="features" replace/>} />
+              <Route index element={<Navigate to="features" replace />} />
             </Routes>
           </SearchIndexContext.Provider>
         )}

--- a/packages/site/src/components/App.tsx
+++ b/packages/site/src/components/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Routes, Route, redirect } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 
 import { Header } from "./Header";
 import { Footer } from "./Footer";
@@ -63,9 +63,6 @@ export function App() {
         {fetchedSearchIndex && (
           <SearchIndexContext.Provider value={{ isLoaded: true, data: fetchedSearchIndex }}>
             <Routes>
-              {/* @TODO: try redirecting to /features */}
-              <Route path="/" element={<ListFeatures />} />
-
               <Route path="features">
                 <Route index element={<ListFeatures />} />
 
@@ -75,23 +72,11 @@ export function App() {
                   <Route path="variables" element={<DisplayFeatureVariablesSchema />} />
                   <Route path="rules" element={<DisplayFeatureRules />}>
                     <Route path=":environmentKey" element={<DisplayFeatureRulesTable />} />
-                    <Route
-                      path="*"
-                      loader={({ params }) =>
-                        /* @TODO: fix redirection */
-                        redirect(`/features/${params.featureKey}/rules/${environmentKeys[0]}`)
-                      }
-                    />
+                    <Route index element={<Navigate to={environmentKeys[0]} replace/>} />
                   </Route>
                   <Route path="force" element={<DisplayFeatureForce />}>
                     <Route path=":environmentKey" element={<DisplayFeatureForceTable />} />
-                    <Route
-                      path="*"
-                      loader={({ params }) =>
-                        /* @TODO: fix redirection */
-                        redirect(`/features/${params.featureKey}/force/${environmentKeys[0]}`)
-                      }
-                    />
+                    <Route index element={<Navigate to={environmentKeys[0]} replace/>} />
                   </Route>
                   <Route path="history" element={<DisplayFeatureHistory />} />
                 </Route>
@@ -118,6 +103,7 @@ export function App() {
               </Route>
 
               <Route path="history" element={<ListHistory />} />
+              <Route index element={<Navigate to="features" replace/>} />
             </Routes>
           </SearchIndexContext.Provider>
         )}

--- a/packages/site/src/components/ShowFeature.tsx
+++ b/packages/site/src/components/ShowFeature.tsx
@@ -439,6 +439,7 @@ export function ShowFeature() {
     {
       title: "Overview",
       to: `/features/${featureKey}`,
+      end: true,
     },
     {
       title: "Variations",

--- a/packages/site/src/components/Tabs.tsx
+++ b/packages/site/src/components/Tabs.tsx
@@ -4,6 +4,7 @@ import { NavLink } from "react-router-dom";
 interface Tab {
   title: string;
   to: string;
+  end?: boolean;
 }
 
 interface TabsProps {
@@ -20,7 +21,7 @@ export function Tabs(props: TabsProps) {
           <NavLink
             key={tab.title}
             to={tab.to}
-            end
+            end={Boolean(tab.end)}
             className={({ isActive }) =>
               [
                 "w-1/4",


### PR DESCRIPTION
This PR adds three small site navigation improvements

1. Initial auto-redirect to `/features` (it was working only on the page, not in the URL)
2. Auto-select first environment in Features _Rules_ and _Forces_ pages
3. Keep _Rules_ and _Forces_ tabs selected when navigating into an environment


![Oct-26-2023 11-48-29](https://github.com/featurevisor/featurevisor/assets/3715587/3190898a-9193-4acb-9601-6e7606e662df)
