### PR TITLE
feat: datasource adapters now handling full CRUD

### DIFF
--- a/packages/core/src/datasource/adapter.ts
+++ b/packages/core/src/datasource/adapter.ts
@@ -11,8 +11,8 @@ export abstract class Adapter {
   // entities
   abstract listEntities(entityType: EntityType): Promise<string[]>;
   abstract entityExists(entityType: EntityType, entityKey: string): Promise<boolean>;
-  abstract readEntity(entityType: EntityType, entityKey: string): Promise<string>;
-  abstract parseEntity<T>(entityType: EntityType, entityKey: string): Promise<T>;
+  abstract readEntity<T>(entityType: EntityType, entityKey: string): Promise<T>;
+  abstract writeEntity<T>(entityType: EntityType, entityKey: string, entity: T): Promise<T>;
 
   // state
   abstract readState(environment: EnvironmentKey): Promise<ExistingState>;

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -67,6 +67,10 @@ export class Datasource {
     return this.adapter.readEntity<ParsedFeature>("feature", featureKey);
   }
 
+  writeFeature(featureKey: FeatureKey, feature: ParsedFeature) {
+    return this.adapter.writeEntity<ParsedFeature>("feature", featureKey, feature);
+  }
+
   async getRequiredFeaturesChain(
     featureKey: FeatureKey,
     chain = new Set<FeatureKey>(),
@@ -109,6 +113,10 @@ export class Datasource {
     return this.adapter.readEntity<Segment>("segment", segmentKey);
   }
 
+  writeSegment(segmentKey: SegmentKey, segment: Segment) {
+    return this.adapter.writeEntity<Segment>("segment", segmentKey, segment);
+  }
+
   // attributes
   listAttributes() {
     return this.adapter.listEntities("attribute");
@@ -120,6 +128,10 @@ export class Datasource {
 
   readAttribute(attributeKey: AttributeKey) {
     return this.adapter.readEntity<Attribute>("attribute", attributeKey);
+  }
+
+  writeAttribute(attributeKey: AttributeKey, attribute: Attribute) {
+    return this.adapter.writeEntity<Attribute>("attribute", attributeKey, attribute);
   }
 
   // groups
@@ -135,6 +147,10 @@ export class Datasource {
     return this.adapter.readEntity<Group>("group", groupKey);
   }
 
+  writeGroup(groupKey: string, group: Group) {
+    return this.adapter.writeEntity<Group>("group", groupKey, group);
+  }
+
   // tests
   listTests() {
     return this.adapter.listEntities("test");
@@ -142,6 +158,10 @@ export class Datasource {
 
   readTest(testKey: string) {
     return this.adapter.readEntity<Test>("test", testKey);
+  }
+
+  writeTest(testKey: string, test: Test) {
+    return this.adapter.writeEntity<Test>("test", testKey, test);
   }
 
   getTestSpecName(testKey: string) {

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -64,7 +64,7 @@ export class Datasource {
   }
 
   readFeature(featureKey: FeatureKey) {
-    return this.adapter.parseEntity<ParsedFeature>("feature", featureKey);
+    return this.adapter.readEntity<ParsedFeature>("feature", featureKey);
   }
 
   async getRequiredFeaturesChain(
@@ -106,7 +106,7 @@ export class Datasource {
   }
 
   readSegment(segmentKey: SegmentKey) {
-    return this.adapter.parseEntity<Segment>("segment", segmentKey);
+    return this.adapter.readEntity<Segment>("segment", segmentKey);
   }
 
   // attributes
@@ -119,7 +119,7 @@ export class Datasource {
   }
 
   readAttribute(attributeKey: AttributeKey) {
-    return this.adapter.parseEntity<Attribute>("attribute", attributeKey);
+    return this.adapter.readEntity<Attribute>("attribute", attributeKey);
   }
 
   // groups
@@ -132,7 +132,7 @@ export class Datasource {
   }
 
   readGroup(groupKey: string) {
-    return this.adapter.parseEntity<Group>("group", groupKey);
+    return this.adapter.readEntity<Group>("group", groupKey);
   }
 
   // tests
@@ -141,7 +141,7 @@ export class Datasource {
   }
 
   readTest(testKey: string) {
-    return this.adapter.parseEntity<Test>("test", testKey);
+    return this.adapter.readEntity<Test>("test", testKey);
   }
 
   getTestSpecName(testKey: string) {

--- a/packages/core/src/datasource/filesystemAdapter.ts
+++ b/packages/core/src/datasource/filesystemAdapter.ts
@@ -63,17 +63,23 @@ export class FilesystemAdapter extends Adapter {
     return fs.existsSync(entityPath);
   }
 
-  async readEntity(entityType: EntityType, entityKey: string): Promise<string> {
-    const filePath = this.getEntityPath(entityType, entityKey);
-
-    return fs.readFileSync(filePath, "utf8");
-  }
-
-  async parseEntity<T>(entityType: EntityType, entityKey: string): Promise<T> {
+  async readEntity<T>(entityType: EntityType, entityKey: string): Promise<T> {
     const filePath = this.getEntityPath(entityType, entityKey);
     const entityContent = fs.readFileSync(filePath, "utf8");
 
     return this.parser.parse<T>(entityContent, filePath);
+  }
+
+  async writeEntity<T>(entityType: EntityType, entityKey: string, entity: T): Promise<T> {
+    const filePath = this.getEntityPath(entityType, entityKey);
+
+    if (!fs.existsSync(this.getEntityDirectoryPath(entityType))) {
+      mkdirp.sync(this.getEntityDirectoryPath(entityType));
+    }
+
+    fs.writeFileSync(filePath, this.parser.stringify(entity));
+
+    return entity;
   }
 
   /**


### PR DESCRIPTION
**NOTE**: Only internal APIs have changed, without breaking anything for consumers.

## What's done

- Datasource adapter interface now handles all CRUD methods
- New `writeEntity` method introduced in Adapter
- `parseEntity` method is now `readEntity`, since parsing is an internal implementation details not needed to be exposed to Datasource consumers