### PR TITLE
fix: using not operator in feature rules

### DIFF
--- a/examples/example-1/attributes/version.yml
+++ b/examples/example-1/attributes/version.yml
@@ -1,0 +1,2 @@
+description: Version number of the app
+type: string # as semver

--- a/examples/example-1/features/footer.yml
+++ b/examples/example-1/features/footer.yml
@@ -1,0 +1,19 @@
+description: Checks `not` operator in segments
+tags:
+  - all
+
+bucketBy: userId
+
+environments:
+  staging:
+    rules:
+      - key: "1"
+        segments:
+          - not:
+              - version_5.5
+        percentage: 100
+  production:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 80

--- a/examples/example-1/segments/version_5.5.yml
+++ b/examples/example-1/segments/version_5.5.yml
@@ -1,0 +1,10 @@
+description: Version equals to 5.5
+conditions:
+  - or:
+      - attribute: version
+        operator: equals
+        value: 5.5
+
+      - attribute: version
+        operator: equals
+        value: "5.5"

--- a/examples/example-1/tests/footer.spec.yml
+++ b/examples/example-1/tests/footer.spec.yml
@@ -1,0 +1,31 @@
+feature: footer
+assertions:
+  - at: 40
+    environment: production
+    context:
+      version: 4
+    expectedToBeEnabled: true
+
+  - at: 40
+    environment: production
+    context:
+      version: 5.4
+    expectedToBeEnabled: true
+
+  - at: 40
+    environment: production
+    context:
+      version: "5"
+    expectedToBeEnabled: true
+
+  - at: 40
+    environment: production
+    context:
+      version: 5.5
+    expectedToBeEnabled: false
+
+  - at: 40
+    environment: production
+    context:
+      version: "5.5"
+    expectedToBeEnabled: false

--- a/examples/example-1/tests/footer.spec.yml
+++ b/examples/example-1/tests/footer.spec.yml
@@ -1,31 +1,31 @@
 feature: footer
 assertions:
   - at: 40
-    environment: production
+    environment: staging
     context:
       version: 4
     expectedToBeEnabled: true
 
   - at: 40
-    environment: production
+    environment: staging
     context:
       version: 5.4
     expectedToBeEnabled: true
 
   - at: 40
-    environment: production
+    environment: staging
     context:
       version: "5"
     expectedToBeEnabled: true
 
   - at: 40
-    environment: production
+    environment: staging
     context:
       version: 5.5
     expectedToBeEnabled: false
 
   - at: 40
-    environment: production
+    environment: staging
     context:
       version: "5.5"
     expectedToBeEnabled: false

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -25,6 +25,12 @@ export function extractSegmentKeysFromGroupSegments(
         result.add(segmentKey);
       });
     }
+
+    if ("not" in segments) {
+      extractSegmentKeysFromGroupSegments(segments.not).forEach((segmentKey) => {
+        result.add(segmentKey);
+      });
+    }
   }
 
   if (typeof segments === "string") {
@@ -59,6 +65,12 @@ export function extractAttributeKeysFromConditions(
 
   if ("or" in conditions) {
     extractAttributeKeysFromConditions(conditions.or).forEach((attributeKey) => {
+      result.add(attributeKey);
+    });
+  }
+
+  if ("not" in conditions) {
+    extractAttributeKeysFromConditions(conditions.not).forEach((attributeKey) => {
       result.add(attributeKey);
     });
   }

--- a/packages/sdk/src/segments.spec.ts
+++ b/packages/sdk/src/segments.spec.ts
@@ -413,6 +413,8 @@ describe("sdk: Segments", function () {
       const group = groups.find((g) => g.key === "notVersion5.5") as Group;
 
       // match
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(true);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(true);
       expect(
         allGroupSegmentsAreMatched(group.segments, { version: "5.6" }, datafileReader),
       ).toEqual(true);
@@ -427,7 +429,6 @@ describe("sdk: Segments", function () {
       );
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(group.segments, { version: "5.5" }, datafileReader),
       ).toEqual(false);

--- a/packages/sdk/src/segments.spec.ts
+++ b/packages/sdk/src/segments.spec.ts
@@ -64,6 +64,16 @@ describe("sdk: Segments", function () {
           },
         ],
       },
+
+      // version
+      {
+        key: "notVersion5.5",
+        segments: [
+          {
+            not: ["version_5.5"],
+          },
+        ],
+      },
     ];
 
     const datafileContent: DatafileContent = {
@@ -135,6 +145,27 @@ describe("sdk: Segments", function () {
               attribute: "country",
               operator: "equals",
               value: "de",
+            },
+          ],
+        },
+
+        // version
+        {
+          key: "version_5.5",
+          conditions: [
+            {
+              or: [
+                {
+                  attribute: "version",
+                  operator: "equals",
+                  value: "5.5",
+                },
+                {
+                  attribute: "version",
+                  operator: "equals",
+                  value: 5.5,
+                },
+              ],
             },
           ],
         },
@@ -376,6 +407,33 @@ describe("sdk: Segments", function () {
           datafileReader,
         ),
       ).toEqual(false);
+    });
+
+    it("should match notVersion5.5", function () {
+      const group = groups.find((g) => g.key === "notVersion5.5") as Group;
+
+      // match
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { version: "5.6" }, datafileReader),
+      ).toEqual(true);
+      expect(allGroupSegmentsAreMatched(group.segments, { version: 5.6 }, datafileReader)).toEqual(
+        true,
+      );
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { version: "5.7" }, datafileReader),
+      ).toEqual(true);
+      expect(allGroupSegmentsAreMatched(group.segments, { version: 5.7 }, datafileReader)).toEqual(
+        true,
+      );
+
+      // not match
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { version: "5.5" }, datafileReader),
+      ).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, { version: 5.5 }, datafileReader)).toEqual(
+        false,
+      );
     });
   });
 });

--- a/packages/sdk/src/segments.ts
+++ b/packages/sdk/src/segments.ts
@@ -39,9 +39,8 @@ export function allGroupSegmentsAreMatched(
     }
 
     if ("not" in groupSegments && Array.isArray(groupSegments.not)) {
-      return groupSegments.not.every(
-        (groupSegment) =>
-          allGroupSegmentsAreMatched(groupSegment, context, datafileReader) === false,
+      return (
+        allGroupSegmentsAreMatched({ and: groupSegments.not }, context, datafileReader) === false
       );
     }
   }

--- a/packages/sdk/src/segments.ts
+++ b/packages/sdk/src/segments.ts
@@ -39,8 +39,9 @@ export function allGroupSegmentsAreMatched(
     }
 
     if ("not" in groupSegments && Array.isArray(groupSegments.not)) {
-      return (
-        allGroupSegmentsAreMatched({ and: groupSegments.not }, context, datafileReader) === false
+      return groupSegments.not.every(
+        (groupSegment) =>
+          allGroupSegmentsAreMatched(groupSegment, context, datafileReader) === false,
       );
     }
   }


### PR DESCRIPTION
The bug was in datafile builder, which did not manage to extract segment keys which were used via `not` operator in the feature's rules.

SDK remains unaffected.