### PR TITLE
feat: filter tests and support verbosity for debugging

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -133,7 +133,7 @@ $ featurevisor test --keyPattern="myKeyHere"
 If you are writing assertion descriptions, then you can filter them further using regex patterns:
 
 ```
-$ feature test --keyPattern="myKeyHere" --assertionPattern="text..."
+$ featurevisor test --keyPattern="myKeyHere" --assertionPattern="text..."
 ```
 
 ### `verbose`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,3 +117,49 @@ $ featurevisor test
 ```
 
 If any of your assertions fail in any test specs, it will terminate with a non-zero exit code.
+
+## CLI options
+
+### `keyPattern`
+
+You can also filter tests by feature or segment keys using regex patterns:
+
+```
+$ featurevisor test --keyPattern="myKeyHere"
+```
+
+### `assertionPattern`
+
+If you are writing assertion descriptions, then you can filter them further using regex patterns:
+
+```
+$ feature test --keyPattern="myKeyHere" --assertionPattern="text..."
+```
+
+### `verbose`
+
+For debugging purposes, you can enable verbose mode to see more details of your assertion evaluations
+
+```
+$ featurevisor test --verbose
+```
+
+## NPM scripts
+
+If you are using npm scripts for testing your Featurevisor project like this:
+
+```js
+// package.json
+
+{
+  "scripts": {
+    "test": "featurevisor test"
+  }
+}
+```
+
+You can then pass your options in CLI after `--`:
+
+```
+$ npm test -- --keyPattern="myKeyHere"
+```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
   findDuplicateSegmentsInProject,
   BuildCLIOptions,
   GenerateCodeCLIOptions,
+  TestProjectOptions,
   restoreProject,
   Dependencies,
   Datasource,
@@ -137,7 +138,12 @@ async function main() {
       handler: async function (options) {
         const deps = await getDependencies(options);
 
-        const hasError = await testProject(deps);
+        const testOptions: TestProjectOptions = {
+          keyPattern: options.keyPattern,
+          assertionPattern: options.assertionPattern,
+        };
+
+        const hasError = await testProject(deps, testOptions);
 
         if (hasError) {
           process.exit(1);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -141,6 +141,7 @@ async function main() {
         const testOptions: TestProjectOptions = {
           keyPattern: options.keyPattern,
           assertionPattern: options.assertionPattern,
+          verbose: options.verbose || false,
         };
 
         const hasError = await testProject(deps, testOptions);

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -14,6 +14,7 @@ export async function testFeature(
   datasource: Datasource,
   projectConfig: ProjectConfig,
   test: TestFeature,
+  patterns,
 ): Promise<boolean> {
   let hasError = false;
   const featureKey = test.feature;
@@ -22,9 +23,15 @@ export async function testFeature(
 
   for (let aIndex = 0; aIndex < test.assertions.length; aIndex++) {
     const assertion = test.assertions[aIndex];
-    const description = assertion.description || `at ${assertion.at}%`;
+    const description = `  Assertion #${aIndex + 1}: (${assertion.environment}) ${
+      assertion.description || `at ${assertion.at}%`
+    }`;
 
-    console.log(`  Assertion #${aIndex + 1}: (${assertion.environment}) ${description}`);
+    if (patterns.assertionPattern && !patterns.assertionPattern.test(description)) {
+      continue;
+    }
+
+    console.log(description);
 
     const requiredChain = await datasource.getRequiredFeaturesChain(test.feature);
     const featuresToInclude = Array.from(requiredChain);

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -14,6 +14,7 @@ export async function testFeature(
   datasource: Datasource,
   projectConfig: ProjectConfig,
   test: TestFeature,
+  options: { verbose?: boolean } = {},
   patterns,
 ): Promise<boolean> {
   let hasError = false;
@@ -54,10 +55,11 @@ export async function testFeature(
       configureBucketValue: () => {
         return assertion.at * (MAX_BUCKETED_NUMBER / 100);
       },
-      // logger: createLogger({
-      //   levels: ["debug", "info", "warn", "error"],
-      // }),
     });
+
+    if (options.verbose) {
+      sdk.setLogLevels(["debug", "info", "warn", "error"]);
+    }
 
     // isEnabled
     if ("expectedToBeEnabled" in assertion) {

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -10,6 +10,7 @@ import { Dependencies } from "../dependencies";
 export interface TestProjectOptions {
   keyPattern?: string;
   assertionPattern?: string;
+  verbose?: boolean;
 }
 
 export async function testProject(
@@ -71,7 +72,7 @@ export async function testProject(
 
       console.log(CLI_FORMAT_BOLD, `\nTesting: ${testFilePath.replace(rootDirectoryPath, "")}`);
 
-      const featureHasError = await testFeature(datasource, projectConfig, test, patterns);
+      const featureHasError = await testFeature(datasource, projectConfig, test, options, patterns);
 
       if (featureHasError) {
         hasError = true;

--- a/packages/core/src/tester/testSegment.ts
+++ b/packages/core/src/tester/testSegment.ts
@@ -5,7 +5,11 @@ import { Datasource } from "../datasource";
 
 import { CLI_FORMAT_BOLD, CLI_FORMAT_RED } from "./cliFormat";
 
-export async function testSegment(datasource: Datasource, test: TestSegment): Promise<boolean> {
+export async function testSegment(
+  datasource: Datasource,
+  test: TestSegment,
+  patterns,
+): Promise<boolean> {
   let hasError = false;
 
   const segmentKey = test.segment;
@@ -25,9 +29,13 @@ export async function testSegment(datasource: Datasource, test: TestSegment): Pr
   const conditions = parsedSegment.conditions as Condition | Condition[];
 
   test.assertions.forEach(function (assertion, aIndex) {
-    const description = assertion.description || `#${aIndex + 1}`;
+    const description = `  Assertion #${aIndex + 1}: ${assertion.description || `#${aIndex + 1}`}`;
 
-    console.log(`  Assertion #${aIndex + 1}: ${description}`);
+    if (patterns.assertionPattern && !patterns.assertionPattern.test(description)) {
+      return;
+    }
+
+    console.log(description);
 
     const expected = assertion.expectedToMatch;
     const actual = allConditionsAreMatched(conditions, assertion.context);

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -19,7 +19,7 @@ import {
   VariableSchema,
 } from "@featurevisor/types";
 
-import { createLogger, Logger } from "./logger";
+import { createLogger, Logger, LogLevel } from "./logger";
 import { DatafileReader } from "./datafileReader";
 import { Emitter } from "./emitter";
 import { getBucketedNumber } from "./bucket";
@@ -263,6 +263,10 @@ export class FeaturevisorInstance {
         "Featurevisor SDK instance cannot be created without both `datafile` and `datafileUrl` options",
       );
     }
+  }
+
+  setLogLevels(levels: LogLevel[]) {
+    this.logger.setLevels(levels);
   }
 
   onReady(): Promise<FeaturevisorInstance> {


### PR DESCRIPTION
Closes #209 and #210 

## What's introduced

Featurevisor tests can be now run with some additional options in CLI:

```
$ featurevisor test
$ featurevisor test --keyPattern="myFeatureKey|mySegmentKey"
$ featurevisor test --keyPattern="myFeatureKey|mySegmentKey" --assertionPattern="assertion description"
$ featurevisor test --verbose
```

If you are using `featurevisor test` as an npm script like:

```js
// package.json

{
  "scripts": {
    "test": "featurevisor test"
  }
}
```

Then do:

```
$ npm test -- --keyPattern="myKeyHere"
```