### PR TITLE
feat: attribute type for semver

### DIFF
--- a/packages/core/src/linter/attributeSchema.ts
+++ b/packages/core/src/linter/attributeSchema.ts
@@ -3,7 +3,7 @@ import * as Joi from "joi";
 export function getAttributeJoiSchema() {
   const attributeJoiSchema = Joi.object({
     archived: Joi.boolean(),
-    type: Joi.string().allow("boolean", "string", "integer", "double", "date").required(),
+    type: Joi.string().valid("boolean", "string", "integer", "double", "date", "semver").required(),
     description: Joi.string().required(),
     capture: Joi.boolean(),
   });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,8 @@ export interface Context {
   [key: AttributeKey]: AttributeValue;
 }
 
+export type AttributeType = "boolean" | "string" | "integer" | "double" | "date" | "semver";
+
 export interface Attribute {
   archived?: boolean; // only available in YAML
   key: AttributeKey;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,7 +11,7 @@ export type AttributeType = "boolean" | "string" | "integer" | "double" | "date"
 export interface Attribute {
   archived?: boolean; // only available in YAML
   key: AttributeKey;
-  type: string;
+  type: AttributeType;
   capture?: boolean;
 }
 


### PR DESCRIPTION
Closes #205

## What's done

- Fixes linting issue for checking attribute types
- Introduces new `semver` attribute type, making way for #208 

Not a breaking change in any way.