### PR TITLE
feat: require certain fields in features and tests when linting

### DIFF
--- a/packages/core/src/linter/featureSchema.ts
+++ b/packages/core/src/linter/featureSchema.ts
@@ -67,8 +67,8 @@ export function getFeatureJoiSchema(
         Joi.object({
           key: Joi.string().required(),
           description: Joi.string().optional(),
-          segments: groupSegmentsJoiSchema,
-          percentage: Joi.number().precision(3).min(0).max(100),
+          segments: groupSegmentsJoiSchema.required(),
+          percentage: Joi.number().precision(3).min(0).max(100).required(),
 
           enabled: Joi.boolean().optional(),
           variation: variationValueJoiSchema.optional(), // @TODO: only allowed if feature.variations is present
@@ -79,7 +79,7 @@ export function getFeatureJoiSchema(
       .required(),
     force: Joi.array().items(
       Joi.object({
-        // @TODO: either of the two below
+        // @TODO: either of the two below should be required
         segments: groupSegmentsJoiSchema.optional(),
         conditions: conditionsJoiSchema.optional(),
 

--- a/packages/core/src/linter/testSchema.ts
+++ b/packages/core/src/linter/testSchema.ts
@@ -27,11 +27,11 @@ export function getTestsJoiSchema(
     assertions: Joi.array().items(
       Joi.object({
         description: Joi.string().optional(),
-        at: Joi.number().precision(3).min(0).max(100),
-        environment: Joi.string().valid(...projectConfig.environments),
-        context: Joi.object(),
-
-        // @TODO: one or all below
+        at: Joi.number().precision(3).min(0).max(100).required(),
+        environment: Joi.string()
+          .valid(...projectConfig.environments)
+          .required(),
+        context: Joi.object().required(),
         expectedToBeEnabled: Joi.boolean().required(),
         expectedVariation: Joi.alternatives().try(Joi.string(), Joi.number(), Joi.boolean()),
         expectedVariables: Joi.object(),


### PR DESCRIPTION
Closes #218 

## What's done

- Feature's rules must have a `percentage` property
- Test assertions should require certain properties too

## Why minor release?

Treated as a `feat` because if some existing users were defining the entities without the properties that are made required via this PR, it will fail their build. Which is a good thing.