### PR TITLE
fix: forcing variation with variable overrides

### DIFF
--- a/examples/example-1/features/foo.yml
+++ b/examples/example-1/features/foo.yml
@@ -34,6 +34,12 @@ variations:
 
 environments:
   staging:
+    force:
+      - conditions:
+          - attribute: userId
+            operator: equals
+            value: "test-force-id"
+        variation: treatment
     rules:
       - key: "1"
         segments: "*"

--- a/examples/example-1/tests/foo.spec.yml
+++ b/examples/example-1/tests/foo.spec.yml
@@ -50,4 +50,4 @@ assertions:
     expectedVariation: treatment
     expectedVariables:
       bar: bar for DE or CH
-      # baz: baz_here
+      baz: baz_here

--- a/examples/example-1/tests/foo.spec.yml
+++ b/examples/example-1/tests/foo.spec.yml
@@ -40,3 +40,14 @@ assertions:
     expectedVariables:
       bar: bar for DE or CH
       baz: baz_here
+
+  - at: 20
+    environment: staging
+    context:
+      country: de
+      userId: test-force-id
+    expectedToBeEnabled: true
+    expectedVariation: treatment
+    expectedVariables:
+      bar: bar for DE or CH
+      # baz: baz_here

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -18,7 +18,7 @@ export function getMatchedAllocation(
   return undefined;
 }
 
-function parseFromStringifiedSegments(value) {
+export function parseFromStringifiedSegments(value) {
   if (typeof value === "string" && (value.startsWith("{") || value.startsWith("["))) {
     return JSON.parse(value);
   }

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -997,6 +997,11 @@ describe("sdk: instance", function () {
                 defaultValue: false,
               },
               {
+                key: "sidebarTitle",
+                type: "string",
+                defaultValue: "sidebar title",
+              },
+              {
                 key: "count",
                 type: "integer",
                 defaultValue: 0,
@@ -1053,6 +1058,26 @@ describe("sdk: instance", function () {
                       },
                     ],
                   },
+                  {
+                    key: "sidebarTitle",
+                    value: "sidebar title from variation",
+                    overrides: [
+                      {
+                        segments: ["netherlands"],
+                        value: "Dutch title",
+                      },
+                      {
+                        conditions: [
+                          {
+                            attribute: "country",
+                            operator: "equals",
+                            value: "de",
+                          },
+                        ],
+                        value: "German title",
+                      },
+                    ],
+                  },
                 ],
               },
             ],
@@ -1068,6 +1093,13 @@ describe("sdk: instance", function () {
               {
                 conditions: [{ attribute: "userId", operator: "equals", value: "user-gb" }],
                 enabled: false,
+              },
+              {
+                conditions: [
+                  { attribute: "userId", operator: "equals", value: "user-forced-variation" },
+                ],
+                enabled: true,
+                variation: "treatment",
               },
             ],
             traffic: [
@@ -1166,6 +1198,25 @@ describe("sdk: instance", function () {
         country: "de",
       }),
     ).toEqual(false);
+
+    expect(
+      sdk.getVariableString("test", "sidebarTitle", {
+        userId: "user-forced-variation",
+        country: "de",
+      }),
+    ).toEqual("German title");
+    expect(
+      sdk.getVariableString("test", "sidebarTitle", {
+        userId: "user-forced-variation",
+        country: "nl",
+      }),
+    ).toEqual("Dutch title");
+    expect(
+      sdk.getVariableString("test", "sidebarTitle", {
+        userId: "user-forced-variation",
+        country: "be",
+      }),
+    ).toEqual("sidebar title from variation");
 
     expect(sdk.getVariable("test", "count", context)).toEqual(0);
     expect(sdk.getVariableInteger("test", "count", context)).toEqual(0);


### PR DESCRIPTION
## Background

- Features can have variations: https://featurevisor.com/docs/features/#variations
- Variations can have variables: https://featurevisor.com/docs/features/#variable-types
- Furthermore, those variables inside variations can have overrides: https://featurevisor.com/docs/features/#overriding-variables

Forcing:

- Variations can be forced: https://featurevisor.com/docs/features/#force

## The issue

When forcing a variation from rules, without forcing variables, the forced variation is not honoured when evaluating its variables.

## The fix

When evaluating variables, it will now check if there happens to be any forced variation.

If any forced variation, it will then honour the variation value before evaluating the variable values.

Otherwise, it will continue with its regular bucketing logic.

## Tests

- Issue has been reproduced via `example-1` project, including its own test spec
- And also unit tests at SDK package level