### PR TITLE
chore: show duration in test runner

### DIFF
--- a/packages/core/src/tester/matrix.ts
+++ b/packages/core/src/tester/matrix.ts
@@ -105,7 +105,7 @@ export function getFeatureAssertionsFromMatrix(
 ): FeatureAssertion[] {
   if (!assertionWithMatrix.matrix) {
     const assertion = { ...assertionWithMatrix };
-    assertion.description = `  Assertion #${aIndex + 1}: (${assertion.environment}) ${
+    assertion.description = `Assertion #${aIndex + 1}: (${assertion.environment}) ${
       assertion.description || `at ${assertion.at}%`
     }`;
 
@@ -118,7 +118,7 @@ export function getFeatureAssertionsFromMatrix(
   for (let cIndex = 0; cIndex < combinations.length; cIndex++) {
     const combination = combinations[cIndex];
     const assertion = applyCombinationToFeatureAssertion(combination, assertionWithMatrix);
-    assertion.description = `  Assertion #${aIndex + 1}: (${assertion.environment}) ${
+    assertion.description = `Assertion #${aIndex + 1}: (${assertion.environment}) ${
       assertion.description || `at ${assertion.at}%`
     }`;
 
@@ -161,7 +161,7 @@ export function getSegmentAssertionsFromMatrix(
 ): SegmentAssertion[] {
   if (!assertionWithMatrix.matrix) {
     const assertion = { ...assertionWithMatrix };
-    assertion.description = `  Assertion #${aIndex + 1}: ${
+    assertion.description = `Assertion #${aIndex + 1}: ${
       assertion.description || `#${aIndex + 1}`
     }`;
 
@@ -174,7 +174,7 @@ export function getSegmentAssertionsFromMatrix(
   for (let cIndex = 0; cIndex < combinations.length; cIndex++) {
     const combination = combinations[cIndex];
     const assertion = applyCombinationToSegmentAssertion(combination, assertionWithMatrix);
-    assertion.description = `  Assertion #${aIndex + 1}: ${
+    assertion.description = `Assertion #${aIndex + 1}: ${
       assertion.description || `#${aIndex + 1}`
     }`;
 

--- a/packages/core/src/tester/prettyDuration.ts
+++ b/packages/core/src/tester/prettyDuration.ts
@@ -1,0 +1,30 @@
+export function prettyDuration(diffInMs) {
+  let diff = Math.abs(diffInMs);
+
+  const ms = diff % 1000;
+  diff = (diff - ms) / 1000;
+  const secs = diff % 60;
+  diff = (diff - secs) / 60;
+  const mins = diff % 60;
+  const hrs = (diff - mins) / 60;
+
+  let result = "";
+
+  if (hrs) {
+    result += ` ${hrs}h`;
+  }
+
+  if (mins) {
+    result += ` ${mins}m`;
+  }
+
+  if (secs) {
+    result += ` ${secs}s`;
+  }
+
+  if (ms) {
+    result += ` ${ms}ms`;
+  }
+
+  return result.trim();
+}

--- a/packages/core/src/tester/prettyDuration.ts
+++ b/packages/core/src/tester/prettyDuration.ts
@@ -1,6 +1,10 @@
 export function prettyDuration(diffInMs) {
   let diff = Math.abs(diffInMs);
 
+  if (diff === 0) {
+    return `0ms`;
+  }
+
   const ms = diff % 1000;
   diff = (diff - ms) / 1000;
   const secs = diff % 60;

--- a/packages/core/src/tester/printTestResult.ts
+++ b/packages/core/src/tester/printTestResult.ts
@@ -1,9 +1,15 @@
 import { TestResult } from "@featurevisor/types";
 
 import { CLI_FORMAT_BOLD, CLI_FORMAT_RED } from "./cliFormat";
+import { prettyDuration } from "./prettyDuration";
 
 export function printTestResult(testResult: TestResult, testFilePath, rootDirectoryPath) {
-  console.log(CLI_FORMAT_BOLD, `\nTesting: ${testFilePath.replace(rootDirectoryPath, "")}`);
+  console.log("");
+
+  const title = `Testing: ${testFilePath.replace(rootDirectoryPath, "")} (${prettyDuration(
+    testResult.duration,
+  )})`;
+  console.log(title);
 
   if (testResult.notFound) {
     console.log(CLI_FORMAT_RED, `  => ${testResult.type} ${testResult.key} not found`);
@@ -15,15 +21,32 @@ export function printTestResult(testResult: TestResult, testFilePath, rootDirect
 
   testResult.assertions.forEach(function (assertion) {
     if (assertion.passed) {
-      console.log(`  ✔ ${assertion.description}`);
+      console.log(`  ✔ ${assertion.description} (${prettyDuration(assertion.duration)})`);
     } else {
-      console.log(CLI_FORMAT_RED, `  ✘ ${assertion.description}`);
+      console.log(
+        CLI_FORMAT_RED,
+        `  ✘ ${assertion.description} (${prettyDuration(assertion.duration)})`,
+      );
 
       assertion.errors?.forEach(function (error) {
-        console.log(
-          CLI_FORMAT_RED,
-          `    => ${error.type}: expected "${error.expected}" but got "${error.actual}"`,
-        );
+        if (error.message) {
+          console.log(CLI_FORMAT_RED, `    => ${error.message}`);
+
+          return;
+        }
+
+        if (error.type === "variable") {
+          const variableKey = (error.details as any).variableKey;
+
+          console.log(CLI_FORMAT_RED, `    => variable key: ${variableKey}`);
+          console.log(CLI_FORMAT_RED, `       => expected: ${error.expected}`);
+          console.log(CLI_FORMAT_RED, `       => received: ${error.actual}`);
+        } else {
+          console.log(
+            CLI_FORMAT_RED,
+            `    => ${error.type}: expected "${error.expected}", received "${error.actual}"`,
+          );
+        }
       });
     }
   });

--- a/packages/core/src/tester/printTestResult.ts
+++ b/packages/core/src/tester/printTestResult.ts
@@ -1,0 +1,30 @@
+import { TestResult } from "@featurevisor/types";
+
+import { CLI_FORMAT_BOLD, CLI_FORMAT_RED } from "./cliFormat";
+
+export function printTestResult(testResult: TestResult, testFilePath, rootDirectoryPath) {
+  console.log(CLI_FORMAT_BOLD, `\nTesting: ${testFilePath.replace(rootDirectoryPath, "")}`);
+
+  if (testResult.notFound) {
+    console.log(CLI_FORMAT_RED, `  => ${testResult.type} ${testResult.key} not found`);
+
+    return;
+  }
+
+  console.log(CLI_FORMAT_BOLD, `  ${testResult.type} "${testResult.key}":`);
+
+  testResult.assertions.forEach(function (assertion) {
+    if (assertion.passed) {
+      console.log(`  ✔ ${assertion.description}`);
+    } else {
+      console.log(CLI_FORMAT_RED, `  ✘ ${assertion.description}`);
+
+      assertion.errors?.forEach(function (error) {
+        console.log(
+          CLI_FORMAT_RED,
+          `    => ${error.type}: expected "${error.expected}" but got "${error.actual}"`,
+        );
+      });
+    }
+  });
+}

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -146,7 +146,7 @@ export async function testFeature(
               type: "variable",
               expected: assertion.expectedVariation,
               actual: undefined,
-              message: `schema for variable ${variableKey} not found in feature`,
+              message: `schema for variable "${variableKey}" not found in feature`,
             });
 
             return;
@@ -176,6 +176,9 @@ export async function testFeature(
                 expected:
                   typeof expectedValue !== "string" ? JSON.stringify(expectedValue) : expectedValue,
                 actual: typeof actualValue !== "string" ? JSON.stringify(actualValue) : actualValue,
+                details: {
+                  variableKey,
+                },
               });
             }
           } else {
@@ -196,6 +199,9 @@ export async function testFeature(
                 type: "variable",
                 expected: expectedValue as string,
                 actual: actualValue as string,
+                details: {
+                  variableKey,
+                },
               });
             }
           }

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -4,7 +4,7 @@ import { TestSegment, TestFeature } from "@featurevisor/types";
 
 import { testSegment } from "./testSegment";
 import { testFeature } from "./testFeature";
-import { CLI_FORMAT_BOLD, CLI_FORMAT_GREEN, CLI_FORMAT_RED } from "./cliFormat";
+import { CLI_FORMAT_GREEN, CLI_FORMAT_RED } from "./cliFormat";
 import { Dependencies } from "../dependencies";
 import { prettyDuration } from "./prettyDuration";
 import { printTestResult } from "./printTestResult";
@@ -80,11 +80,10 @@ export async function testProject(
         continue;
       }
 
-      console.log(CLI_FORMAT_BOLD, `\nTesting: ${testFilePath.replace(rootDirectoryPath, "")}`);
+      const testResult = await testFeature(datasource, projectConfig, test, options, patterns);
+      printTestResult(testResult, testFilePath, rootDirectoryPath);
 
-      const featureHasError = await testFeature(datasource, projectConfig, test, options, patterns);
-
-      if (featureHasError) {
+      if (!testResult.passed) {
         hasError = true;
         failedCount++;
       } else {

--- a/packages/core/src/tester/testSegment.ts
+++ b/packages/core/src/tester/testSegment.ts
@@ -16,6 +16,7 @@ export async function testSegment(
   test: TestSegment,
   patterns,
 ): Promise<TestResult> {
+  const testStartTime = Date.now();
   const segmentKey = test.segment;
 
   const testResult: TestResult = {
@@ -41,8 +42,6 @@ export async function testSegment(
   const parsedSegment = await datasource.readSegment(segmentKey);
   const conditions = parsedSegment.conditions as Condition | Condition[];
 
-  const testStartTime = Date.now();
-
   test.assertions.forEach(function (assertion, aIndex) {
     const assertions = getSegmentAssertionsFromMatrix(aIndex, assertion);
 
@@ -63,8 +62,6 @@ export async function testSegment(
       const actual = allConditionsAreMatched(conditions, assertion.context);
       const passed = actual === expected;
 
-      testResultAssertion.passed = passed;
-
       if (!passed) {
         const testResultAssertionError: TestResultAssertionError = {
           type: "segment",
@@ -73,6 +70,8 @@ export async function testSegment(
         };
 
         (testResultAssertion.errors as TestResultAssertionError[]).push(testResultAssertionError);
+        testResult.passed = false;
+        testResultAssertion.passed = passed;
       }
 
       testResult.assertions.push(testResultAssertion);

--- a/packages/core/src/tester/testSegment.ts
+++ b/packages/core/src/tester/testSegment.ts
@@ -1,57 +1,86 @@
-import { TestSegment, Condition } from "@featurevisor/types";
+import {
+  TestSegment,
+  Condition,
+  TestResult,
+  TestResultAssertion,
+  TestResultAssertionError,
+} from "@featurevisor/types";
 import { allConditionsAreMatched } from "@featurevisor/sdk";
 
 import { Datasource } from "../datasource";
 
-import { CLI_FORMAT_BOLD, CLI_FORMAT_RED } from "./cliFormat";
 import { getSegmentAssertionsFromMatrix } from "./matrix";
 
 export async function testSegment(
   datasource: Datasource,
   test: TestSegment,
   patterns,
-): Promise<boolean> {
-  let hasError = false;
-
+): Promise<TestResult> {
   const segmentKey = test.segment;
 
-  console.log(CLI_FORMAT_BOLD, `  Segment "${segmentKey}":`);
+  const testResult: TestResult = {
+    type: "segment",
+    key: segmentKey,
+
+    // to be updated later
+    notFound: false,
+    duration: 0,
+    passed: true,
+    assertions: [],
+  };
 
   const segmentExists = await datasource.segmentExists(segmentKey);
 
   if (!segmentExists) {
-    console.error(CLI_FORMAT_RED, `  Segment does not exist: ${segmentKey}`);
-    hasError = true;
+    testResult.notFound = true;
+    testResult.passed = false;
 
-    return hasError;
+    return testResult;
   }
 
   const parsedSegment = await datasource.readSegment(segmentKey);
   const conditions = parsedSegment.conditions as Condition | Condition[];
 
+  const testStartTime = Date.now();
+
   test.assertions.forEach(function (assertion, aIndex) {
     const assertions = getSegmentAssertionsFromMatrix(aIndex, assertion);
 
     assertions.forEach(function (assertion) {
+      const assertionStartTime = Date.now();
+      const testResultAssertion: TestResultAssertion = {
+        description: assertion.description as string,
+        duration: 0,
+        passed: true,
+        errors: [],
+      };
+
       if (patterns.assertionPattern && !patterns.assertionPattern.test(assertion.description)) {
         return;
       }
 
-      console.log(assertion.description);
-
       const expected = assertion.expectedToMatch;
       const actual = allConditionsAreMatched(conditions, assertion.context);
+      const passed = actual === expected;
 
-      if (actual !== expected) {
-        hasError = true;
+      testResultAssertion.passed = passed;
 
-        console.error(
-          CLI_FORMAT_RED,
-          `    Segment failed: expected "${expected}", got "${actual}"`,
-        );
+      if (!passed) {
+        const testResultAssertionError: TestResultAssertionError = {
+          type: "segment",
+          expected,
+          actual,
+        };
+
+        (testResultAssertion.errors as TestResultAssertionError[]).push(testResultAssertionError);
       }
+
+      testResult.assertions.push(testResultAssertion);
+      testResultAssertion.duration = Date.now() - assertionStartTime;
     });
   });
 
-  return hasError;
+  testResult.duration = Date.now() - testStartTime;
+
+  return testResult;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -393,6 +393,7 @@ export interface TestResultAssertionError {
   type: "flag" | "variation" | "variable" | "segment";
   expected: string | number | boolean | Date | null | undefined;
   actual: string | number | boolean | Date | null | undefined;
+  message?: string;
   details?: object;
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -389,6 +389,29 @@ export interface TestSegment {
 
 export type Test = TestSegment | TestFeature;
 
+export interface TestResultAssertionError {
+  type: "flag" | "variation" | "variable" | "segment";
+  expected: string | number | boolean | Date | null | undefined;
+  actual: string | number | boolean | Date | null | undefined;
+  details?: object;
+}
+
+export interface TestResultAssertion {
+  description: string;
+  duration: number;
+  passed: boolean;
+  errors?: TestResultAssertionError[];
+}
+
+export interface TestResult {
+  type: "feature" | "segment";
+  key: string;
+  notFound?: boolean;
+  passed: boolean;
+  duration: number;
+  assertions: TestResultAssertion[];
+}
+
 /**
  * Site index and history
  */


### PR DESCRIPTION
## Background

We have a test runner: https://featurevisor.com/docs/testing/

## What's done

- Get a summary of all tests passed/failed
- Get duration info at assertion level, and also at whole test level

This will help with #237 later.