### PR TITLE
feat: print feature datafile

### DIFF
--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -51,3 +51,15 @@ You can optionally customize the `revision` value in datafiles by passing a `--r
 ```
 $ featurevisor build --revision 1.2.3
 ```
+
+## Printing
+
+You can print the contents of a datafile for a single feature without writing anything to disk by passing these flags:
+
+```
+$ featurevisor build --feature=foo --environment=production --print --pretty
+```
+
+This is useful primarily for debugging and testing purposes.
+
+If you are an SDK developer in other languages besides JavaScript, you may want to use this handy command to get the generated datafile content in JSON format that you can use in your own [test runner](/docs/testing).

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -3,15 +3,53 @@ import * as path from "path";
 import { SCHEMA_VERSION } from "../config";
 
 import { buildDatafile } from "./buildDatafile";
+import { getDatafileForFeature } from "../tester";
 import { Dependencies } from "../dependencies";
 
 export interface BuildCLIOptions {
   revision?: string;
+
+  // all three together
+  environment?: string;
+  feature?: string;
+  print?: boolean;
+  pretty?: boolean;
 }
 
 export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptions = {}) {
   const { rootDirectoryPath, projectConfig, datasource } = deps;
 
+  /**
+   * This build process does not write to disk, and prints only to stdout.
+   *
+   * This is ideally for test runners in other languages,
+   * when they wish to get datafile for a single feature,
+   * so they can run tests against their own SDKs in other languages.
+   *
+   * This way we centralize the datafile generation in one place,
+   * while tests can be run anywhere else.
+   */
+  if (cliOptions.environment && cliOptions.feature && cliOptions.print) {
+    const datafileContent = await getDatafileForFeature(
+      cliOptions.feature,
+      cliOptions.environment,
+      projectConfig,
+      datasource,
+      cliOptions.revision,
+    );
+
+    if (cliOptions.pretty) {
+      console.log(JSON.stringify(datafileContent, null, 2));
+    } else {
+      console.log(JSON.stringify(datafileContent));
+    }
+
+    return;
+  }
+
+  /**
+   * Regular build process that writes to disk.
+   */
   const tags = projectConfig.tags;
   const environments = projectConfig.environments;
 

--- a/packages/core/src/tester/index.ts
+++ b/packages/core/src/tester/index.ts
@@ -1,1 +1,2 @@
 export * from "./testProject";
+export * from "./testFeature";


### PR DESCRIPTION
## What's done

You can print the contents of a datafile for a single feature without writing anything to disk by passing these flags:

```
$ featurevisor build --feature=foo --environment=production --print --pretty
```

This is useful primarily for debugging and testing purposes.

If you are an SDK developer in other languages besides JavaScript, you may want to use this handy command to get the generated datafile content in JSON format that you can use in your own test runner.