### PR TITLE
feat: additional advanced search options in generated site

### DIFF
--- a/docs/site.md
+++ b/docs/site.md
@@ -64,6 +64,8 @@ Examples:
 - `in:production`: search features by environment
 - `archived:true` or `archived:false`
 - `capture:true` or `capture:false`: for filtering attributes
+- `with:variations` or `without:variations`: for filtering features with/without variations
+- `with:variables` or `without:variables`: for filtering features with/without variables
 
 ## Read-only mode
 

--- a/docs/site.md
+++ b/docs/site.md
@@ -65,7 +65,9 @@ Examples:
 - `archived:true` or `archived:false`
 - `capture:true` or `capture:false`: for filtering attributes
 - `with:variations` or `without:variations`: for filtering features with/without variations
+- `variation:variation-value`: for filtering features by variation value
 - `with:variables` or `without:variables`: for filtering features with/without variables
+- `variable:variable-key`: for filtering features by variable key
 
 ## Read-only mode
 

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -8,6 +8,8 @@ export interface Query {
   capture?: boolean;
   hasVariations?: boolean;
   hasVariables?: boolean;
+  variableKeys?: string[];
+  variationValues?: string[];
 }
 
 export function parseSearchQuery(queryString: string) {
@@ -49,6 +51,26 @@ export function parseSearchQuery(queryString: string) {
         query.capture = true;
       } else if (capture === "false") {
         query.capture = false;
+      }
+    } else if (part.startsWith("variable")) {
+      const variableKey = part.replace("variable:", "");
+
+      if (typeof query.variableKeys === "undefined") {
+        query.variableKeys = [];
+      }
+
+      if (variableKey.length > 0) {
+        query.variableKeys.push(variableKey);
+      }
+    } else if (part.startsWith("variation")) {
+      const variationValue = part.replace("variation:", "");
+
+      if (typeof query.variationValues === "undefined") {
+        query.variationValues = [];
+      }
+
+      if (variationValue.length > 0) {
+        query.variationValues.push(variationValue);
       }
     } else if (part === "with:variations") {
       query.hasVariations = true;
@@ -144,6 +166,30 @@ export function getFeaturesByQuery(query: Query, data: SearchIndex) {
 
         if (!query.hasVariations && feature.variations) {
           matched = false;
+        }
+      }
+
+      if (typeof query.variationValues !== "undefined") {
+        if (!feature.variations) {
+          matched = false;
+        } else {
+          const valuesFromFeature = feature.variations.map((v: any) => v.value);
+
+          if (query.variationValues.some((v) => valuesFromFeature.indexOf(v) === -1)) {
+            matched = false;
+          }
+        }
+      }
+
+      if (typeof query.variableKeys !== "undefined") {
+        if (!feature.variablesSchema) {
+          matched = false;
+        } else {
+          const keysFromFeature = feature.variablesSchema.map((v: any) => v.key);
+
+          if (query.variableKeys.some((k) => keysFromFeature.indexOf(k) === -1)) {
+            matched = false;
+          }
         }
       }
 

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -52,7 +52,7 @@ export function parseSearchQuery(queryString: string) {
       } else if (capture === "false") {
         query.capture = false;
       }
-    } else if (part.startsWith("variable")) {
+    } else if (part.startsWith("variable:")) {
       const variableKey = part.replace("variable:", "");
 
       if (typeof query.variableKeys === "undefined") {
@@ -62,7 +62,7 @@ export function parseSearchQuery(queryString: string) {
       if (variableKey.length > 0) {
         query.variableKeys.push(variableKey);
       }
-    } else if (part.startsWith("variation")) {
+    } else if (part.startsWith("variation:")) {
       const variationValue = part.replace("variation:", "");
 
       if (typeof query.variationValues === "undefined") {

--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -6,6 +6,8 @@ export interface Query {
   environments: string[];
   archived?: boolean;
   capture?: boolean;
+  hasVariations?: boolean;
+  hasVariables?: boolean;
 }
 
 export function parseSearchQuery(queryString: string) {
@@ -48,6 +50,14 @@ export function parseSearchQuery(queryString: string) {
       } else if (capture === "false") {
         query.capture = false;
       }
+    } else if (part === "with:variations") {
+      query.hasVariations = true;
+    } else if (part === "without:variations") {
+      query.hasVariations = false;
+    } else if (part === "with:variables") {
+      query.hasVariables = true;
+    } else if (part === "without:variables") {
+      query.hasVariables = false;
     } else {
       if (part.length > 0) {
         query.keyword = part;
@@ -123,6 +133,26 @@ export function getFeaturesByQuery(query: Query, data: SearchIndex) {
         }
 
         if (!query.archived && feature.archived === true) {
+          matched = false;
+        }
+      }
+
+      if (typeof query.hasVariations !== "undefined") {
+        if (query.hasVariations && !feature.variations) {
+          matched = false;
+        }
+
+        if (!query.hasVariations && feature.variations) {
+          matched = false;
+        }
+      }
+
+      if (typeof query.hasVariables !== "undefined") {
+        if (query.hasVariables && !feature.variablesSchema) {
+          matched = false;
+        }
+
+        if (!query.hasVariables && feature.variablesSchema) {
           matched = false;
         }
       }


### PR DESCRIPTION
## Background

https://featurevisor.com/docs/site/

## Examples

Previously existing:

- `my keyword`: plain search
- `tag:my-tag`: search features by tag
- `in:production`: search features by environment
- `archived:true` or `archived:false`
- `capture:true` or `capture:false`: for filtering attributes

New additions:

- `with:variations` or `without:variations`: for filtering features with/without variations
- `variation:variation-value`: for filtering features by variation value
- `with:variables` or `without:variables`: for filtering features with/without variables
- `variable:variable-key`: for filtering features by variable key