### PR TITLE
fix: linting should pick up non-array matrix values in tests

### DIFF
--- a/packages/core/src/linter/printError.ts
+++ b/packages/core/src/linter/printError.ts
@@ -6,12 +6,20 @@ export function printZodError(e: ZodError) {
   const { issues } = e;
 
   issues.forEach((issue) => {
-    console.error(CLI_FORMAT_RED, `  => Error: ${issue.message}`);
-    console.error("     Path:", issue.path.join("."));
+    if (issue.code === "invalid_union" && issue.path.length === 0 && issue.unionErrors.length > 0) {
+      // invalid_union
+      const lastUnionError = issue.unionErrors[issue.unionErrors.length - 1];
+      console.error(CLI_FORMAT_RED, `  => Error: ${lastUnionError.issues[0].message}`);
+      console.error("     Path:", lastUnionError.issues[0].path.join("."));
+    } else {
+      // others
+      console.error(CLI_FORMAT_RED, `  => Error: ${issue.message}`);
+      console.error("     Path:", issue.path.join("."));
 
-    const receivedValue = (issue as any).received;
-    if (typeof receivedValue !== "undefined" && receivedValue !== "undefined") {
-      console.error("     Value:", receivedValue);
+      const receivedValue = (issue as any).received;
+      if (typeof receivedValue !== "undefined" && receivedValue !== "undefined") {
+        console.error("     Value:", receivedValue);
+      }
     }
 
     if (issues.length > 1) {

--- a/packages/core/src/linter/testSchema.ts
+++ b/packages/core/src/linter/testSchema.ts
@@ -7,6 +7,18 @@ export function getTestsZodSchema(
   availableFeatureKeys: [string, ...string[]],
   availableSegmentKeys: [string, ...string[]],
 ) {
+  const matrixZodSchema = z.record(
+    z.array(
+      z.union([
+        // allowed values in arrays
+        z.string(),
+        z.number(),
+        z.boolean(),
+        z.null(),
+      ]),
+    ),
+  );
+
   const segmentTestZodSchema = z
     .object({
       segment: z.string().refine(
@@ -18,7 +30,7 @@ export function getTestsZodSchema(
       assertions: z.array(
         z
           .object({
-            matrix: z.record(z.unknown()).optional(), // @TODO: make it stricter
+            matrix: matrixZodSchema.optional(),
             description: z.string().optional(),
             context: z.record(z.unknown()),
             expectedToMatch: z.boolean(),
@@ -39,7 +51,7 @@ export function getTestsZodSchema(
       assertions: z.array(
         z
           .object({
-            matrix: z.record(z.unknown()).optional(), // @TODO: make it stricter
+            matrix: matrixZodSchema.optional(),
             description: z.string().optional(),
             at: z.union([
               z.number().min(0).max(100),


### PR DESCRIPTION
## Issue

Before, you could mistakenly pass strings as values in a matrix, like:

```yml
# tests/my.feature.yml
feature: my
assertions:
  - matrix:
      environment: [production]
      at: [85, 90]
      country: [nl]
      city: [amsterdam, utrecht]
      somethingWithWrongValue: wrong value here # see here
    at: ${{ at }}
    environment: ${{ environment }}
    context:
      country: ${{ country }}
      city: ${{ city }}
    expectedToBeEnabled: false
```

## Fix

Linting made stricter to pick this kind of issues up early.

Zod error printer updated to handle union errors in a more user friendly way.