### PR TITLE
feat: allow option to test by generating datafiles early

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -204,6 +204,18 @@ $ featurevisor test --showDatafile
 
 Printing datafile content for each and every tested feature can be very verbose, so we recommend using this option with `--keyPattern` to filter tests.
 
+### `fast`
+
+By default, Featurevisor's test runner would generate a datafile for your feature against the desired environment for each assertion.
+
+If you have a lot of tests, this can be time-consuming. You can use the `--fast` option to generate datafiles for each environment early packing all the features in the project together, and then run the assertions:
+
+```
+$ featurevisor test --fast
+```
+
+**Note**: This approach is memory intensive and therefore not the default behaviour yet.
+
 ## NPM scripts
 
 If you are using npm scripts for testing your Featurevisor project like this:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -148,7 +148,7 @@ async function main() {
           assertionPattern: options.assertionPattern,
           verbose: options.verbose || false,
           showDatafile: options.showDatafile || false,
-          singleDatafile: options.singleDatafile || false,
+          fast: options.fast || false,
         };
 
         const hasError = await testProject(deps, testOptions);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -148,6 +148,7 @@ async function main() {
           assertionPattern: options.assertionPattern,
           verbose: options.verbose || false,
           showDatafile: options.showDatafile || false,
+          singleDatafile: options.singleDatafile || false,
         };
 
         const hasError = await testProject(deps, testOptions);

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -32,6 +32,7 @@ export interface BuildOptions {
   environment: string;
   tag?: string;
   features?: FeatureKey[];
+  includeAllFeatures?: boolean;
 }
 
 export async function buildDatafile(
@@ -66,23 +67,28 @@ export async function buildDatafile(
         continue;
       }
 
-      if (options.tag && parsedFeature.tags.indexOf(options.tag) === -1) {
-        continue;
-      }
-
-      if (options.features && options.features.indexOf(featureKey) === -1) {
-        continue;
-      }
-
-      if (parsedFeature.environments[options.environment].expose === false) {
-        continue;
-      }
-
-      if (Array.isArray(parsedFeature.environments[options.environment].expose)) {
-        const exposeTags = parsedFeature.environments[options.environment].expose as string[];
-
-        if (options.tag && exposeTags.indexOf(options.tag) === -1) {
+      if (
+        typeof options.includeAllFeatures === "undefined" ||
+        options.includeAllFeatures === false
+      ) {
+        if (options.tag && parsedFeature.tags.indexOf(options.tag) === -1) {
           continue;
+        }
+
+        if (options.features && options.features.indexOf(featureKey) === -1) {
+          continue;
+        }
+
+        if (parsedFeature.environments[options.environment].expose === false) {
+          continue;
+        }
+
+        if (Array.isArray(parsedFeature.environments[options.environment].expose)) {
+          const exposeTags = parsedFeature.environments[options.environment].expose as string[];
+
+          if (options.tag && exposeTags.indexOf(options.tag) === -1) {
+            continue;
+          }
         }
       }
 

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -32,7 +32,6 @@ export interface BuildOptions {
   environment: string;
   tag?: string;
   features?: FeatureKey[];
-  includeAllFeatures?: boolean;
 }
 
 export async function buildDatafile(
@@ -67,28 +66,23 @@ export async function buildDatafile(
         continue;
       }
 
-      if (
-        typeof options.includeAllFeatures === "undefined" ||
-        options.includeAllFeatures === false
-      ) {
-        if (options.tag && parsedFeature.tags.indexOf(options.tag) === -1) {
+      if (options.tag && parsedFeature.tags.indexOf(options.tag) === -1) {
+        continue;
+      }
+
+      if (options.features && options.features.indexOf(featureKey) === -1) {
+        continue;
+      }
+
+      if (parsedFeature.environments[options.environment].expose === false) {
+        continue;
+      }
+
+      if (Array.isArray(parsedFeature.environments[options.environment].expose)) {
+        const exposeTags = parsedFeature.environments[options.environment].expose as string[];
+
+        if (options.tag && exposeTags.indexOf(options.tag) === -1) {
           continue;
-        }
-
-        if (options.features && options.features.indexOf(featureKey) === -1) {
-          continue;
-        }
-
-        if (parsedFeature.environments[options.environment].expose === false) {
-          continue;
-        }
-
-        if (Array.isArray(parsedFeature.environments[options.environment].expose)) {
-          const exposeTags = parsedFeature.environments[options.environment].expose as string[];
-
-          if (options.tag && exposeTags.indexOf(options.tag) === -1) {
-            continue;
-          }
         }
       }
 

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -82,17 +82,15 @@ export async function testFeature(
         continue;
       }
 
-      let datafileContent;
-      if (typeof datafileContentByEnvironment[assertion.environment] !== "undefined") {
-        datafileContent = datafileContentByEnvironment[assertion.environment];
-      } else {
-        datafileContent = await getDatafileForFeature(
-          test.feature,
-          assertion.environment,
-          projectConfig,
-          datasource,
-        );
-      }
+      const datafileContent =
+        typeof datafileContentByEnvironment[assertion.environment] !== "undefined"
+          ? datafileContentByEnvironment[assertion.environment]
+          : await getDatafileForFeature(
+              test.feature,
+              assertion.environment,
+              projectConfig,
+              datasource,
+            );
 
       if (options.showDatafile) {
         console.log("");

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -48,6 +48,7 @@ export async function testFeature(
   test: TestFeature,
   options: { verbose?: boolean; showDatafile?: boolean } = {},
   patterns,
+  datafileContentByEnvironment: { [environment: string]: DatafileContent } = {},
 ): Promise<TestResult> {
   const testStartTime = Date.now();
   const featureKey = test.feature;
@@ -81,12 +82,17 @@ export async function testFeature(
         continue;
       }
 
-      const datafileContent = await getDatafileForFeature(
-        test.feature,
-        assertion.environment,
-        projectConfig,
-        datasource,
-      );
+      let datafileContent;
+      if (typeof datafileContentByEnvironment[assertion.environment] !== "undefined") {
+        datafileContent = datafileContentByEnvironment[assertion.environment];
+      } else {
+        datafileContent = await getDatafileForFeature(
+          test.feature,
+          assertion.environment,
+          projectConfig,
+          datasource,
+        );
+      }
 
       if (options.showDatafile) {
         console.log("");

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -140,7 +140,7 @@ export async function testProject(
   let passedAssertionsCount = 0;
   let failedAssertionsCount = 0;
 
-  let datafileContentByEnvironment: DatafileContentByEnvironment = {};
+  const datafileContentByEnvironment: DatafileContentByEnvironment = {};
   if (options.singleDatafile) {
     for (const environment of projectConfig.environments) {
       const existingState = await datasource.readState(environment);

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -17,7 +17,7 @@ export interface TestProjectOptions {
   assertionPattern?: string;
   verbose?: boolean;
   showDatafile?: boolean;
-  singleDatafile?: boolean;
+  fast?: boolean;
 }
 
 export interface TestPatterns {
@@ -141,7 +141,7 @@ export async function testProject(
   let failedAssertionsCount = 0;
 
   const datafileContentByEnvironment: DatafileContentByEnvironment = {};
-  if (options.singleDatafile) {
+  if (options.fast) {
     for (const environment of projectConfig.environments) {
       const existingState = await datasource.readState(environment);
       const datafileContent = await buildDatafile(
@@ -151,7 +151,6 @@ export async function testProject(
           schemaVersion: SCHEMA_VERSION,
           revision: "include-all-features",
           environment: environment,
-          includeAllFeatures: true,
         },
         existingState,
       );


### PR DESCRIPTION
## Background

We have a test runner: https://featurevisor.com/docs/testing/

It iterates through each spec at a time, and for each feature/environment it generates a datafile on the fly before asserting its expectations.

Meaning, for each feature assertion, it generates a new datafile on the fly.

## What's done

Without changing any existing behaviour, any new CLI option is introduced that will generate the datafiles for test runner early packing all the features for each environment, avoiding the need for generating datafiles too many times.

```
$ npx featurevisor test --fast
```

Without this new `--fast` option, it will continue to behave like it does now.

## Why?

The idea is that this new test runner option would drastically reduce the time taken for all tests to complete in a Featurevisor project, especially those having several hundreds of test specs.

This option can be memory intensive, and that's why it (`--fast`) has not been turned into the default behaviour yet.