### PR TITLE
feat: revisioning info moved to its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,13 @@ The whole process can be broken down into 3 steps:
 
 ## Step 1: Create a Featurevisor project
 
-Install Featurevisor CLI globally (or use `npx @featurevisor/cli`):
-
-```
-$ npm install -g @featurevisor/cli
-```
-
-Initialize a new Featurevisor project:
+Use `npx` to scaffold a new Featurevisor project:
 
 ```
 $ mkdir my-featurevisor-project && cd my-featurevisor-project
-$ featurevisor init
+
+$ npx @featurevisor/cli init
+$ npm install
 ```
 
 You can now create and manage your feature flags, experiments, and remote config in this directory expressed as YAMLs.
@@ -128,7 +124,7 @@ See the building block guides here:
 Once the project is ready, you can build your datafiles (JSON files containing configuration of your feature flags):
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 You will find the output in `dist` directory, that you can upload to your CDN.

--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -10,7 +10,7 @@ Datafiles are JSON files that are created against combinations of tags and envir
 Use Featurevisor CLI to build your datafiles:
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 ## Output
@@ -49,7 +49,7 @@ By default, Featurevisor will use the `version` as exists in `package.json` of t
 You can optionally customize the `revision` value in datafiles by passing a `--revision` flag when building:
 
 ```
-$ featurevisor build --revision 1.2.3
+$ npx featurevisor build --revision 1.2.3
 ```
 
 ## Printing
@@ -57,13 +57,13 @@ $ featurevisor build --revision 1.2.3
 You can print the contents of a datafile for a single feature in/or an environment without writing anything to disk by passing these flags:
 
 ```
-$ featurevisor build --feature=foo --environment=production --print --pretty
+$ npx featurevisor build --feature=foo --environment=production --print --pretty
 ```
 
 Or if you with to print datafile containing all features for a specific environment:
 
 ```
-$ featurevisor build --environment=production --print --pretty
+$ npx featurevisor build --environment=production --print --pretty
 ```
 
 This is useful primarily for debugging and testing purposes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,33 +8,29 @@ Beyond just initializing a project and building datafiles, Featurevisor CLI can 
 
 ## Installation
 
-Install with `npm`:
+Use `npx` to initialize a project first:
 
 ```
-$ npm install -g @featurevisor/cli
-```
-
-Or use `npx` to run the CLI without installing it:
-
-```
-$ npx @featurevisor/cli <command>
-```
-
-Rest of the documentation assumes that you have installed the CLI globally.
-
-## Initializing a project
-
-Scaffold a new project in your working directory:
-
-```
-$ mkdir my-project && cd my-project
-$ featurevisor init
+$ mkdir my-featurevisor-project && cd my-featurevisor-project
+$ npx @featurevisor/cli init
 ```
 
 If you wish to initialize a specific example as available in the [monorepo](https://github.com/featurevisor/featurevisor/tree/main/examples):
 
 ```
-$ featurevisor init --example <name>
+$ npx @featurevisor/cli init --example <name>
+```
+
+After you have installed the dependencies in the project:
+
+```
+$ npm install
+``
+
+You can access the Featurevisor CLI from inside the project via:
+
+```
+$ npx featurevisor
 ```
 
 Learn more in [Quick start](/docs/quick-start).
@@ -44,7 +40,7 @@ Learn more in [Quick start](/docs/quick-start).
 Check if the YAML files have any syntax or structural errors:
 
 ```
-$ featurevisor lint
+$ npx featurevisor lint
 ```
 
 Lear more in [Linting](/docs/linting).
@@ -54,7 +50,7 @@ Lear more in [Linting](/docs/linting).
 Generate JSON files on a per environment and tag combination as exists in project [configuration](/docs/configuration):
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 Learn more in [Building datafiles](/docs/building-datafiles).
@@ -64,7 +60,7 @@ Learn more in [Building datafiles](/docs/building-datafiles).
 Test your features and segments:
 
 ```
-$ featurevisor test
+$ npx featurevisor test
 ```
 
 Learn more in [Testing](/docs/testing).
@@ -76,7 +72,7 @@ Building datafiles also generates [state files](/docs/state-files).
 To restore them to last known state in Git, run:
 
 ```
-$ featurevisor restore
+$ npx featurevisor restore
 ```
 
 ## Generate static site
@@ -84,19 +80,19 @@ $ featurevisor restore
 Build the site:
 
 ```
-$ featurevisor site export
+$ npx featurevisor site export
 ```
 
 Serve the built site (defaults to port 3000):
 
 ```
-$ featurevisor site serve
+$ npx featurevisor site serve
 ```
 
 Serve it in a specific port:
 
 ```
-$ featurevisor site serve -p 3000
+$ npx featurevisor site serve -p 3000
 ```
 
 Learn more in [Status site](/docs/status-site).
@@ -107,7 +103,7 @@ Learn more in [Status site](/docs/status-site).
 Generate TypeScript code from your YAMLs:
 
 ```
-$ featurevisor generate-code --language typescript --out-dir ./src
+$ npx featurevisor generate-code --language typescript --out-dir ./src
 ```
 
 See output in `./src` directory.
@@ -121,5 +117,5 @@ It is possible to end up with multiple segments having same conditions in larger
 We can find these duplicates early on by running:
 
 ```
-$ featurevisor find-duplicate-segments
+$ npx featurevisor find-duplicate-segments
 ```

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -27,7 +27,7 @@ Support for other languages is planned in future, as Featurevisor SDK becomes av
 From the root of your Featurevisor project directory, use the [CLI](/docs/cli) for generating code in a specified directory:
 
 ```
-$ featurevisor generate-code --language typescript --out-dir ./src
+$ npx featurevisor generate-code --language typescript --out-dir ./src
 ```
 
 The generated files can be found in `./src` directory.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -16,7 +16,7 @@ When a new Pull Request (branch) is merged, the CI/CD pipeline should:
 Lint all the attributes, segments, and feature definitions:
 
 ```
-$ featurevisor lint
+$ npx featurevisor lint
 ```
 
 ### Testing
@@ -24,13 +24,13 @@ $ featurevisor lint
 Test all the features and segments:
 
 ```
-$ featurevisor test
+$ npx featurevisor test
 ```
 
 ### Build the datafiles
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 ### Commit the state files

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,7 +37,7 @@ $ featurevisor build
 
 ```
 $ git add .featurevisor/*
-$ git commit -m "State files"
+$ git commit -m "[skip ci] Revision $(cat .featurevisor/REVISION)"
 ```
 
 Only the [state files](/docs/state-files) should be committed as available under `.featurevisor` directory. The generated datafiles in `dist` directory are ignored from Git.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,21 +11,21 @@ We recommend that you set up a CI/CD pipeline to automate the build and deployme
 
 When a new Pull Request (branch) is merged, the CI/CD pipeline should:
 
-### Lint your files
+### Linting
 
 Lint all the attributes, segments, and feature definitions:
 
 ```
-$ fearurevisor lint
+$ featurevisor lint
 ```
 
-### Version your project
+### Testing
+
+Test all the features and segments:
 
 ```
-$ npm version patch
+$ featurevisor test
 ```
-
-The new `version` value as available in `package.json` file will be used when building datafiles.
 
 ### Build the datafiles
 
@@ -36,11 +36,11 @@ $ featurevisor build
 ### Commit the state files
 
 ```
-$ git add .
+$ git add .featurevisor/*
 $ git commit -m "State files"
 ```
 
-Only the state files should be committed as available under `.featurevisor` directory. The generated datafiles in `dist` directory are ignored.
+Only the [state files](/docs/state-files) should be committed as available under `.featurevisor` directory. The generated datafiles in `dist` directory are ignored from Git.
 
 ### Upload to your CDN
 
@@ -53,7 +53,7 @@ You can use the `dist` directory as the root directory for your CDN.
 We want to make sure the next Pull Request merge will be on top of the latest version and state files.
 
 ```
-$ git push origin main --tags
+$ git push origin main
 ```
 
 If any of the steps above fail, the CI/CD pipeline should stop and notify the team.

--- a/docs/integrations/cloudflare-pages.md
+++ b/docs/integrations/cloudflare-pages.md
@@ -80,11 +80,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build
-        run: npm run build
-
       - name: Test specs
         run: npm test
+
+      - name: Build
+        run: npm run build
 ```
 
 ### Publish
@@ -119,19 +119,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Git configs
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Version
-        run: npm version patch
+      - name: Test specs
+        run: npm test
 
       - name: Build
         run: npm run build
-
-      - name: Test specs
-        run: npm test
 
       - name: Upload to Cloudflare Pages
         run: |
@@ -141,10 +133,15 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
+      - name: Git configs
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: Push back to origin
         run: |
           git add .featurevisor/*
-          git commit --amend --no-edit
+          git commit -m "[skip ci] Revision $(cat .featurevisor/REVISION)"
           git push
 ```
 
@@ -154,8 +151,12 @@ Once uploaded, the your datafiles will be accessible as: `https://<your-project>
 
 You may want to take it a step further by setting up custom domains (or subdomains) for your Cloudflare Pages project. Otherwise, you are good to go.
 
-Learn how too consume datafiles from URLs directly using [SDKs](/docs/sdks).
+Learn how to consume datafiles from URLs directly using [SDKs](/docs/sdks).
 
 ## Full example
 
 You can find a fully functional repository based on this guide here: [https://github.com/featurevisor/featurevisor-example-cloudflare](https://github.com/featurevisor/featurevisor-example-cloudflare).
+
+## Sequential builds
+
+In case you are worried about simultaneous builds triggered by multiple Pull Requests merged in quick succession, you can learn about mitigating any unintended issues [here](/docs/integrations/github-actions/#sequential-builds).

--- a/docs/integrations/cloudflare-pages.md
+++ b/docs/integrations/cloudflare-pages.md
@@ -17,12 +17,6 @@ $ mkdir my-featurevisor-project && cd my-featurevisor-project
 $ npx @featurevisor/cli init
 ```
 
-The initialized project will already contain the npm scripts for linting, building, and testing your project:
-
-- `lint`: `featurevisor lint`
-- `build`: `featurevisor build`
-- `test`: `featurevisor test`
-
 ## Cloudflare Pages
 
 We are going to be uploading to and serving our datafiles from [Cloudflare Pages](https://pages.cloudflare.com/).
@@ -78,13 +72,13 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint
+        run: npx featurevisor lint
 
       - name: Test specs
-        run: npm test
+        run: npx featurevisor test
 
       - name: Build
-        run: npm run build
+        run: npx featurevisor build
 ```
 
 ### Publish
@@ -117,13 +111,13 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint
+        run: npx featurevisor lint
 
       - name: Test specs
-        run: npm test
+        run: npx featurevisor test
 
       - name: Build
-        run: npm run build
+        run: npx featurevisor build
 
       - name: Upload to Cloudflare Pages
         run: |

--- a/docs/integrations/cloudflare-pages.md
+++ b/docs/integrations/cloudflare-pages.md
@@ -14,7 +14,9 @@ This guide assumes you have created a new Featurevisor project using the CLI:
 
 ```
 $ mkdir my-featurevisor-project && cd my-featurevisor-project
+
 $ npx @featurevisor/cli init
+$ npm install
 ```
 
 ## Cloudflare Pages

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -14,7 +14,9 @@ This guide assumes you have created a new Featurevisor project using the CLI:
 
 ```
 $ mkdir my-featurevisor-project && cd my-featurevisor-project
+
 $ npx @featurevisor/cli init
+$ npm install
 ```
 
 ## Repository settings

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -65,11 +65,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build
-        run: npm run build
-
       - name: Test specs
         run: npm test
+
+      - name: Build
+        run: npm run build
 ```
 
 ### Publish
@@ -104,31 +104,44 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Git configs
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Version
-        run: npm version patch
+      - name: Test specs
+        run: npm test
 
       - name: Build
         run: npm run build
-
-      - name: Test specs
-        run: npm test
 
       - name: Upload datafiles
         run: echo "Uploading..."
         # Update it accordingly based on your CDN set up
 
+      - name: Git configs
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: Push back to origin
         run: |
           git add .featurevisor/*
-          git commit --amend --no-edit
+          git commit -m "[skip ci] Revision $(cat .featurevisor/REVISION)"
           git push
 ```
 
 After generating new datafiles and uploading them, the workflow will also take care of pushing the Featurevisor [state files](/docs/state-files) back to the repository, so that future builds will be built on top of latest state.
 
 If you want an example of an actual uploading step, see [Cloudflare Pages](/docs/integrations/cloudflare-pages/) integration guide.
+
+## Sequential builds
+
+It is possible you might want to run the publish workflow sequentially for every merged Pull Requests, in case multiple Pull Requests are merged in quick succession.
+
+### Queue
+
+You can consider using [softprops/turnstyle](https://github.com/softprops/turnstyle) GitHub Action to run publish workflow of all your merged Pull Requests sequentially.
+
+### Branch protection rules
+
+Next to it, you can also make it stricter by requiring all Pull Request authors to have their branches up to date from latest main branch before merging:
+
+- [Managing suggestions to update pull request branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-suggestions-to-update-pull-request-branches)
+- [Create branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule#creating-a-branch-protection-rule) (see #7)
+  -  Require branches to be up to date before merging

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -17,12 +17,6 @@ $ mkdir my-featurevisor-project && cd my-featurevisor-project
 $ npx @featurevisor/cli init
 ```
 
-The initialized project will already contain the npm scripts for linting, building, and testing your project:
-
-- `lint`: `featurevisor lint`
-- `build`: `featurevisor build`
-- `test`: `featurevisor test`
-
 ## Repository settings
 
 Make sure you have `Read and write permissions` enabled in your GitHub repository's `Settings > Actions > General > Workflow permissions` section.
@@ -63,13 +57,13 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint
+        run: npx featurevisor lint
 
       - name: Test specs
-        run: npm test
+        run: npx featurevisor test
 
       - name: Build
-        run: npm run build
+        run: npx featurevisor build
 ```
 
 ### Publish
@@ -102,13 +96,13 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint
+        run: npx featurevisor lint
 
       - name: Test specs
-        run: npm test
+        run: npx featurevisor test
 
       - name: Build
-        run: npm run build
+        run: npx featurevisor build
 
       - name: Upload datafiles
         run: echo "Uploading..."

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -10,7 +10,7 @@ Featurevisor provides a CLI command to lint your definition files, making sure t
 Run:
 
 ```
-$ featurevisor lint
+$ npx featurevisor lint
 ```
 
 And it will show you the errors in your definition files, if any.
@@ -24,7 +24,7 @@ If any errors are found, it will terminate with a non-zero exit code.
 You can also filter keys using regex patterns:
 
 ```
-$ featurevisor lint --keyPattern="myKeyHere"
+$ npx featurevisor lint --keyPattern="myKeyHere"
 ```
 
 ### `entityType`
@@ -32,7 +32,7 @@ $ featurevisor lint --keyPattern="myKeyHere"
 If you want to filter it down further by entity type:
 
 ```
-$ featurevisor lint --keyPattern="myKeyHere" --entityType="feature"
+$ npx featurevisor lint --keyPattern="myKeyHere" --entityType="feature"
 ```
 
 Possible values for `--entityType`:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,20 +8,6 @@ ogImage: /img/og/docs-quick-start.png
 
 - [Node.js](https://nodejs.org/en/) >= 16.0.0
 
-## Installation
-
-Easiest way to get started is by using the Featurevisor CLI.
-
-```
-$ npm install -g @featurevisor/cli
-```
-
-If you want to avoid global installation, you can use `npx` instead:
-
-```
-$ npx @featurevisor/cli <command>
-```
-
 ## Initialize your project
 
 This is meant to be a completely separate repository from your application code.
@@ -31,21 +17,21 @@ The idea is to be able to decouple your application deployments from releasing y
 Run the following command to initialize your project:
 
 ```
-$ mkdir my-project && cd my-project
-$ featurevisor init
+$ mkdir my-featurevisor-project && cd my-featurevisor-project
+$ npx @featurevisor/cli init
 ```
 
 If you want to initialize a specific example:
 
 ```
-$ featurevisor init --example <name>
+$ npx @featurevisor/cli init --example <name>
 ```
 
 You can find all available examples [here](/docs/examples).
 
-## Dependencies
+## Installation
 
-We start by installing all the necessary local dependencies:
+Once your project has been initialized, install all the dependencies:
 
 ```
 $ npm install
@@ -153,7 +139,7 @@ environments:
 We can lint the content of all our files to make sure they are all valid:
 
 ```
-$ featurevisor lint
+$ npx featurevisor lint
 ```
 
 Learn more in [Linting](/docs/linting).
@@ -165,7 +151,7 @@ Datafiles are JSON files that we expect our client-side applications to consume 
 Now that we have all the configuration in place, we can build the project:
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 This will generate datafiles in the `dist` directory for each of your tags against each environment as defined in your `featurevisor.config.js` file.

--- a/docs/site.md
+++ b/docs/site.md
@@ -24,7 +24,7 @@ The git repo also needs to have an `origin` remote set up, in order for the edit
 Use Featurevisor CLI:
 
 ```
-$ featurevisor site export
+$ npx featurevisor site export
 ```
 
 The generated static site will be available in the `out` directory.
@@ -34,7 +34,7 @@ The generated static site will be available in the `out` directory.
 Run:
 
 ```
-$ featurevisor site serve
+$ npx featurevisor site serve
 ```
 
 ## Screenshots

--- a/docs/state-files.md
+++ b/docs/state-files.md
@@ -22,7 +22,7 @@ We will learn more about it in [Deployment](/docs/deployment).
 If you have already built your datafiles, you can restore the state files to the last known state in Git by running:
 
 ```
-$ featurevisor restore
+$ npx featurevisor restore
 ```
 
 This will only work if the state files already exist in the Git repository.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -163,7 +163,7 @@ This helps us cover more scenarios by having to write less code in our specs.
 Use the Featurevisor CLI to run your tests:
 
 ```
-$ featurevisor test
+$ npx featurevisor test
 ```
 
 If any of your assertions fail in any test specs, it will terminate with a non-zero exit code.
@@ -175,7 +175,7 @@ If any of your assertions fail in any test specs, it will terminate with a non-z
 You can also filter tests by feature or segment keys using regex patterns:
 
 ```
-$ featurevisor test --keyPattern="myKeyHere"
+$ npx featurevisor test --keyPattern="myKeyHere"
 ```
 
 ### `assertionPattern`
@@ -183,7 +183,7 @@ $ featurevisor test --keyPattern="myKeyHere"
 If you are writing assertion descriptions, then you can filter them further using regex patterns:
 
 ```
-$ featurevisor test --keyPattern="myKeyHere" --assertionPattern="text..."
+$ npx featurevisor test --keyPattern="myKeyHere" --assertionPattern="text..."
 ```
 
 ### `verbose`
@@ -191,7 +191,7 @@ $ featurevisor test --keyPattern="myKeyHere" --assertionPattern="text..."
 For debugging purposes, you can enable verbose mode to see more details of your assertion evaluations
 
 ```
-$ featurevisor test --verbose
+$ npx featurevisor test --verbose
 ```
 
 ### `showDatafile`
@@ -199,7 +199,7 @@ $ featurevisor test --verbose
 For more advanced debugging, you can print the datafile content used by test runner:
 
 ```
-$ featurevisor test --showDatafile
+$ npx featurevisor test --showDatafile
 ```
 
 Printing datafile content for each and every tested feature can be very verbose, so we recommend using this option with `--keyPattern` to filter tests.
@@ -209,7 +209,7 @@ Printing datafile content for each and every tested feature can be very verbose,
 If you are interested to see only the test specs that fail:
 
 ```
-$ featurevisor test --onlyFailures
+$ npx featurevisor test --onlyFailures
 ```
 
 ### `fast`
@@ -219,7 +219,7 @@ By default, Featurevisor's test runner would generate a datafile for your featur
 If you have a lot of tests, this can be time-consuming. You can use the `--fast` option to generate datafiles for each environment early packing all the features in the project together, and then run the assertions:
 
 ```
-$ featurevisor test --fast
+$ npx featurevisor test --fast
 ```
 
 **Note**: This approach is memory intensive and therefore not the default behaviour yet.

--- a/docs/use-cases/microfrontends.md
+++ b/docs/use-cases/microfrontends.md
@@ -102,7 +102,7 @@ module.exports = {
 Once this configuration is in place, we can [build](/docs/building-datafiles) our datafiles:
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 And it will output the following datafiles in the `dist` directory:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,13 +7,7 @@ Visit [https://featurevisor.com/docs/cli](https://featurevisor.com/docs/cli) for
 ## Installation
 
 ```
-$ npm install -g @featurevisor/cli
-```
-
-Or via `npx`:
-
-```
-$ npx featurevisor <command>
+$ npm install --save-dev @featurevisor/cli
 ```
 
 ## Usage
@@ -23,13 +17,15 @@ $ npx featurevisor <command>
 Initialize your project.
 
 ```
-$ featurevisor init
+$ mkdir my-featurevisor-project && cd my-featurevisor-project
+$ npx @featurevisor/cli init
+$ npm install
 ```
 
 If you want to initialize your project with a specific example:
 
 ```
-$ featurevisor init --example <name>
+$ npx @featurevisor/cli init --example <name>
 ```
 
 Examples found [here](../../examples).
@@ -39,7 +35,7 @@ Examples found [here](../../examples).
 Check if your YAMLs are valid.
 
 ```
-$ featurevisor lint
+$ npx featurevisor lint
 ```
 
 
@@ -48,7 +44,7 @@ $ featurevisor lint
 Build your datafiles.
 
 ```
-$ featurevisor build
+$ npx featurevisor build
 ```
 
 ### `test`
@@ -56,7 +52,7 @@ $ featurevisor build
 Test your generated datafiles using the SDK, against specs written in YAMLs.
 
 ```
-$ featurevisor test
+$ npx featurevisor test
 ```
 
 See test specs in YAMLs [here](../../examples/example-1/tests) for inspiration.
@@ -66,8 +62,8 @@ See test specs in YAMLs [here](../../examples/example-1/tests) for inspiration.
 Start a local server to view your project's site.
 
 ```
-$ featurevisor site export
-$ featurevisor site serve
+$ npx featurevisor site export
+$ npx featurevisor site serve
 ```
 
 ## License

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -54,7 +54,8 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
   const environments = projectConfig.environments;
 
   const currentRevision = await datasource.readRevision();
-  const nextRevision = getNextRevision(currentRevision);
+  const nextRevision =
+    (cliOptions.revision && cliOptions.revision.toString()) || getNextRevision(currentRevision);
 
   for (const environment of environments) {
     console.log(`\nBuilding datafiles for environment: ${environment}`);
@@ -69,7 +70,7 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
         datasource,
         {
           schemaVersion: SCHEMA_VERSION,
-          revision: cliOptions.revision || nextRevision,
+          revision: nextRevision,
           environment: environment,
           tag: tag,
         },

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -52,6 +52,8 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
   const environments = projectConfig.environments;
 
   const currentRevision = await datasource.readRevision();
+  console.log("\nCurrent revision:", currentRevision);
+
   const nextRevision =
     (cliOptions.revision && cliOptions.revision.toString()) || getNextRevision(currentRevision);
 
@@ -88,4 +90,6 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
     // write revision
     await datasource.writeRevision(nextRevision);
   }
+
+  console.log("\nLatest revision:", nextRevision);
 }

--- a/packages/core/src/builder/revision.spec.ts
+++ b/packages/core/src/builder/revision.spec.ts
@@ -1,0 +1,22 @@
+import { getNextRevision } from "./revision";
+
+describe("core: Revision", function () {
+  it("should be a function", function () {
+    expect(typeof getNextRevision).toEqual("function");
+  });
+
+  it("should return next version number", function () {
+    // string-string
+    expect(getNextRevision("")).toEqual("1");
+    expect(getNextRevision("random text")).toEqual("1");
+
+    // string-numeric
+    expect(getNextRevision("1")).toEqual("2");
+    expect(getNextRevision("2024")).toEqual("2025");
+
+    // string-semver
+    expect(getNextRevision("1.0.0")).toEqual("1");
+    expect(getNextRevision("0.0.0")).toEqual("1");
+    expect(getNextRevision("0.0.1523")).toEqual("1524");
+  });
+});

--- a/packages/core/src/builder/revision.ts
+++ b/packages/core/src/builder/revision.ts
@@ -1,0 +1,22 @@
+export function getNextRevision(currentRevision: string) {
+  // If the string is empty or can't be parsed with parseInt(), return "1".
+  if (!currentRevision || isNaN(parseInt(currentRevision, 10))) {
+    return "1";
+  }
+
+  // If the string is like an integer, increment it by 1 and return the value.
+  if (currentRevision.indexOf(".") === -1) {
+    return (parseInt(currentRevision, 10) + 1).toString();
+  }
+
+  // If the string is a semver, parse the patch version out of it, increment it by one and return it.
+  const parts = currentRevision.split(".");
+  const lastPart = parseInt(parts[parts.length - 1], 10);
+
+  if (!isNaN(lastPart)) {
+    return (lastPart + 1).toString();
+  }
+
+  // If the string can't be parsed as a semver, return "1".
+  return "1";
+}

--- a/packages/core/src/datasource/adapter.ts
+++ b/packages/core/src/datasource/adapter.ts
@@ -29,6 +29,10 @@ export abstract class Adapter {
   abstract readDatafile(options: DatafileOptions): Promise<DatafileContent>;
   abstract writeDatafile(datafileContent: DatafileContent, options: DatafileOptions): Promise<void>;
 
+  // revision
+  abstract readRevision(): Promise<string>;
+  abstract writeRevision(revision: string): Promise<void>;
+
   // history
   abstract listHistoryEntries(entityType?: EntityType, entityKey?: string): Promise<HistoryEntry[]>;
   abstract readCommit(

--- a/packages/core/src/datasource/datasource.ts
+++ b/packages/core/src/datasource/datasource.ts
@@ -41,6 +41,17 @@ export class Datasource {
   }
 
   /**
+   * Revision
+   */
+  readRevision() {
+    return this.adapter.readRevision();
+  }
+
+  writeRevision(revision: string) {
+    return this.adapter.writeRevision(revision);
+  }
+
+  /**
    * Datafile
    */
   readDatafile(options: DatafileOptions) {


### PR DESCRIPTION
## Background

Featurevisor's build system relied on the `version` found in `package.json` for the generated datafiles' `revision` property.

Links for further understanding:

- https://featurevisor.com/docs/building-datafiles/
- https://featurevisor.com/docs/state-files/
- https://featurevisor.com/docs/deployment/
- https://featurevisor.com/docs/integrations/github-actions/

## Challenges

For every new successful build, it meant incrementing the version number as found in `package.json`.

Many npm projects rely on caching their dependencies, and the cache is busted if the hash of `package.json` and/or `package-lock.json` changes.

If we keep updating the `version` in `package.json` for every build, this way of caching becomes redundant. We don't want that.

## Solution

Now the revision info is stored next to [state files](https://featurevisor.com/docs/state-files/) in `.featurevisor/REVISION` file.

This will contain a numeric value, which will be incremented by every build.

And `package.json` remains untouched and unused going forward, leaving you with the choice to adopt a caching strategy for your npm dependencies the way you want.

## Backwards compatibility

Those who have been following our deployment guide with [GitHub Actions](https://featurevisor.com/docs/integrations/github-actions/) and/or [Cloudflare Pages](https://featurevisor.com/docs/integrations/cloudflare-pages/) before, it will maintain backwards compatibility by:

- taking the last known `version` from `package.json`
- using that as a base and create a new `.featurevisor/REVISION` file
- and use the new file going forward

## How to upgrade?

If you have been following our [deployment guidelines](https://featurevisor.com/docs/deployment/), then it's really nothing more than a version upgrade for `@featurevisor/cli` for you.

But you may want to tweak your pipeline (like [GitHub Actions](https://featurevisor.com/docs/integrations/github-actions/) workflows) to benefit from this change.

## TODOs

- [x] Update docs
- [ ] Update CI/CD example in https://github.com/featurevisor/featurevisor-example-cloudflare