### PR TITLE
feat: allow printing datafile per environment

### DIFF
--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -54,7 +54,7 @@ $ featurevisor build --revision 1.2.3
 
 ## Printing
 
-You can print the contents of a datafile for a single feature and or environment without writing anything to disk by passing these flags:
+You can print the contents of a datafile for a single feature in/or an environment without writing anything to disk by passing these flags:
 
 ```
 $ featurevisor build --feature=foo --environment=production --print --pretty

--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -54,10 +54,16 @@ $ featurevisor build --revision 1.2.3
 
 ## Printing
 
-You can print the contents of a datafile for a single feature without writing anything to disk by passing these flags:
+You can print the contents of a datafile for a single feature and or environment without writing anything to disk by passing these flags:
 
 ```
 $ featurevisor build --feature=foo --environment=production --print --pretty
+```
+
+Or if you with to print datafile containing all features for a specific environment:
+
+```
+$ featurevisor build --environment=production --print --pretty
 ```
 
 This is useful primarily for debugging and testing purposes.

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -2,8 +2,7 @@ import * as path from "path";
 
 import { SCHEMA_VERSION } from "../config";
 
-import { buildDatafile } from "./buildDatafile";
-import { getDatafileForFeature } from "../tester";
+import { buildDatafile, getCustomDatafile } from "./buildDatafile";
 import { Dependencies } from "../dependencies";
 
 export interface BuildCLIOptions {
@@ -23,20 +22,20 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
    * This build process does not write to disk, and prints only to stdout.
    *
    * This is ideally for test runners in other languages,
-   * when they wish to get datafile for a single feature,
+   * when they wish to get datafile for a single feature and/or environment,
    * so they can run tests against their own SDKs in other languages.
    *
    * This way we centralize the datafile generation in one place,
    * while tests can be run anywhere else.
    */
-  if (cliOptions.environment && cliOptions.feature && cliOptions.print) {
-    const datafileContent = await getDatafileForFeature(
-      cliOptions.feature,
-      cliOptions.environment,
+  if (cliOptions.environment && cliOptions.print) {
+    const datafileContent = await getCustomDatafile({
+      featureKey: cliOptions.feature,
+      environment: cliOptions.environment,
       projectConfig,
       datasource,
-      cliOptions.revision,
-    );
+      revision: cliOptions.revision,
+    });
 
     if (cliOptions.pretty) {
       console.log(JSON.stringify(datafileContent, null, 2));

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -9,38 +9,11 @@ import { createInstance, MAX_BUCKETED_NUMBER } from "@featurevisor/sdk";
 
 import { Datasource } from "../datasource";
 import { ProjectConfig } from "../config";
-import { buildDatafile } from "../builder";
-import { SCHEMA_VERSION } from "../config";
+import { getCustomDatafile } from "../builder";
 
 import { checkIfArraysAreEqual } from "./checkIfArraysAreEqual";
 import { checkIfObjectsAreEqual } from "./checkIfObjectsAreEqual";
 import { getFeatureAssertionsFromMatrix } from "./matrix";
-
-export async function getDatafileForFeature(
-  featureKey: string,
-  environment: string,
-  projectConfig: ProjectConfig,
-  datasource: Datasource,
-  revision: string = "testing",
-): Promise<DatafileContent> {
-  const requiredChain = await datasource.getRequiredFeaturesChain(featureKey);
-  const featuresToInclude = Array.from(requiredChain);
-
-  const existingState = await datasource.readState(environment);
-  const datafileContent = await buildDatafile(
-    projectConfig,
-    datasource,
-    {
-      schemaVersion: SCHEMA_VERSION,
-      revision,
-      environment: environment,
-      features: featuresToInclude,
-    },
-    existingState,
-  );
-
-  return datafileContent;
-}
 
 export async function testFeature(
   datasource: Datasource,
@@ -85,12 +58,12 @@ export async function testFeature(
       const datafileContent =
         typeof datafileContentByEnvironment[assertion.environment] !== "undefined"
           ? datafileContentByEnvironment[assertion.environment]
-          : await getDatafileForFeature(
-              test.feature,
-              assertion.environment,
+          : await getCustomDatafile({
+              featureKey: test.feature,
+              environment: assertion.environment,
               projectConfig,
               datasource,
-            );
+            });
 
       if (options.showDatafile) {
         console.log("");


### PR DESCRIPTION
## What's done

Generate and print datafile content on the fly for both specific feature and also all features in a given environment, without affecting any state on the disk.

## Comparison

### Before

We could only do:

```
$ featurevisor build --feature=foo --environment=production --print --pretty
```

### After

Now, we can also print datafile for a specific environment (containing all its features):

```
$ featurevisor build --environment=production --print --pretty
```