### PR TITLE
feat: allow showing only failed specs in test runner

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -204,6 +204,14 @@ $ featurevisor test --showDatafile
 
 Printing datafile content for each and every tested feature can be very verbose, so we recommend using this option with `--keyPattern` to filter tests.
 
+### `onlyFailures`
+
+If you are interested to see only the test specs that fail:
+
+```
+$ featurevisor test --onlyFailures
+```
+
 ### `fast`
 
 By default, Featurevisor's test runner would generate a datafile for your feature against the desired environment for each assertion.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -149,6 +149,7 @@ async function main() {
           verbose: options.verbose || false,
           showDatafile: options.showDatafile || false,
           fast: options.fast || false,
+          onlyFailures: options.onlyFailures || false,
         };
 
         const hasError = await testProject(deps, testOptions);

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -17,6 +17,7 @@ export interface TestProjectOptions {
   assertionPattern?: string;
   verbose?: boolean;
   showDatafile?: boolean;
+  onlyFailures?: boolean;
   fast?: boolean;
 }
 
@@ -88,7 +89,15 @@ export async function executeTest(
     );
   }
 
-  printTestResult(testResult, testFilePath, rootDirectoryPath);
+  if (!options.onlyFailures) {
+    // show all
+    printTestResult(testResult, testFilePath, rootDirectoryPath);
+  } else {
+    // show failed only
+    if (!testResult.passed) {
+      printTestResult(testResult, testFilePath, rootDirectoryPath);
+    }
+  }
 
   if (!testResult.passed) {
     executionResult.passed = false;
@@ -185,7 +194,10 @@ export async function testProject(
 
   const diffInMs = Date.now() - startTime;
 
-  console.log("\n---\n");
+  if (options.onlyFailures !== true || hasError) {
+    console.log("\n---");
+  }
+  console.log("");
 
   const testSpecsMessage = `Test specs: ${passedTestsCount} passed, ${failedTestsCount} failed`;
   const testAssertionsMessage = `Assertions: ${passedAssertionsCount} passed, ${failedAssertionsCount} failed`;


### PR DESCRIPTION
## What's introduced

Additional option for showing only failed test specs when running tests:

```
$ featurevisor test --onlyFailures
```

More info: https://featurevisor.com/docs/testing/