### PR TITLE
fix: init command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,8 +44,9 @@ function requireAndGetProjectConfig(rootDirectoryPath) {
   return getProjectConfig(rootDirectoryPath);
 }
 
+const rootDirectoryPath = process.cwd();
+
 async function getDependencies(options): Promise<Dependencies> {
-  const rootDirectoryPath = process.cwd();
   const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
   const datasource = new Datasource(projectConfig, rootDirectoryPath);
 
@@ -67,8 +68,7 @@ async function main() {
     .command({
       command: "init",
       handler: async function (options) {
-        const deps = await getDependencies(options);
-        const hasError = await initProject(deps.rootDirectoryPath, options.example);
+        const hasError = await initProject(rootDirectoryPath, options.example);
 
         if (hasError) {
           process.exit(1);


### PR DESCRIPTION
## What's done

Pass `rootDirectoryPath` directly, without needing to prepare project dependencies.

Otherwise it wasn't allowing users to `init` a fresh new project.

## How to use

### Globally

```
$ npm install -g @featurevisor/cli

$ mkdir my-featurevisor-project && cd my-featurevisor-project
$ featurevisor init
```

### Using npx

```
$ mkdir my-featurevisor-project && cd my-featurevisor-project
$ npx @featurevisor/cli init
```