### PR TITLE
fix: move to next condition if parsing fails

### DIFF
--- a/examples/example-1/features/showHeader.yml
+++ b/examples/example-1/features/showHeader.yml
@@ -1,0 +1,29 @@
+description: For testing wrong semver parsing
+tags:
+  - all
+
+bucketBy:
+  - userId
+
+environments:
+  staging:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 100
+  production:
+    rules:
+      - key: "desktop"
+        segments:
+          - version_gt5
+          - desktop
+        percentage: 100
+
+      - key: "mobile"
+        segments:
+          - mobile
+        percentage: 100
+
+      - key: "all"
+        segments: "*"
+        percentage: 0

--- a/examples/example-1/segments/desktop.yml
+++ b/examples/example-1/segments/desktop.yml
@@ -1,0 +1,5 @@
+description: desktop users
+conditions:
+  - attribute: device
+    operator: equals
+    value: desktop

--- a/examples/example-1/segments/version_gt5.yml
+++ b/examples/example-1/segments/version_gt5.yml
@@ -1,0 +1,5 @@
+description: Version greater than 5
+conditions:
+  - attribute: version
+    operator: semverGreaterThan
+    value: 5.0.0

--- a/examples/example-1/tests/showHeader.spec.yml
+++ b/examples/example-1/tests/showHeader.spec.yml
@@ -1,0 +1,40 @@
+feature: showHeader
+assertions:
+  - description: "should be disabled for desktop users below v5"
+    at: 80
+    environment: production
+    context:
+      device: desktop
+      version: 1.2.3
+    expectedToBeEnabled: false
+
+  - description: "should be enabled for desktop users above v5"
+    at: 80
+    environment: production
+    context:
+      device: desktop
+      version: 5.5.0
+    expectedToBeEnabled: true
+
+  - description: "should be enabled for mobile users when passing valid semver"
+    at: 80
+    environment: production
+    context:
+      device: mobile
+      version: 1.2.3
+    expectedToBeEnabled: true
+
+  - description: "should be enabled for mobile users when passing invalid semver"
+    at: 80
+    environment: production
+    context:
+      device: mobile
+      version: 7.0.A101.99gbm.lg
+    expectedToBeEnabled: true
+
+  - description: "should be disabled for tablets"
+    at: 80
+    environment: production
+    context:
+      device: tablet
+    expectedToBeEnabled: false

--- a/packages/core/src/tester/testSegment.ts
+++ b/packages/core/src/tester/testSegment.ts
@@ -5,7 +5,7 @@ import {
   TestResultAssertion,
   TestResultAssertionError,
 } from "@featurevisor/types";
-import { allConditionsAreMatched } from "@featurevisor/sdk";
+import { allConditionsAreMatched, createLogger } from "@featurevisor/sdk";
 
 import { Datasource } from "../datasource";
 
@@ -41,6 +41,7 @@ export async function testSegment(
 
   const parsedSegment = await datasource.readSegment(segmentKey);
   const conditions = parsedSegment.conditions as Condition | Condition[];
+  const logger = createLogger();
 
   test.assertions.forEach(function (assertion, aIndex) {
     const assertions = getSegmentAssertionsFromMatrix(aIndex, assertion);
@@ -59,7 +60,7 @@ export async function testSegment(
       }
 
       const expected = assertion.expectedToMatch;
-      const actual = allConditionsAreMatched(conditions, assertion.context);
+      const actual = allConditionsAreMatched(conditions, assertion.context, logger);
       const passed = actual === expected;
 
       if (!passed) {

--- a/packages/sdk/src/conditions.spec.ts
+++ b/packages/sdk/src/conditions.spec.ts
@@ -1,7 +1,11 @@
-import { allConditionsAreMatched } from "./conditions";
 import { Condition } from "@featurevisor/types";
 
+import { allConditionsAreMatched } from "./conditions";
+import { createLogger } from "./logger";
+
 describe("sdk: Conditions", function () {
+  const logger = createLogger();
+
   it("should be a function", function () {
     expect(typeof allConditionsAreMatched).toEqual("function");
   });
@@ -17,10 +21,12 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" }, logger)).toEqual(
+        false,
+      );
     });
 
     it("should match with operator: notEquals", function () {
@@ -33,10 +39,14 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" }, logger)).toEqual(
+        true,
+      );
 
       // not match
-      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" }, logger)).toEqual(
+        false,
+      );
     });
 
     it("should match with operator: startsWith", function () {
@@ -49,11 +59,11 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { name: "Hello World" })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { name: "Hello Universe" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Hello World" }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Hello Universe" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { name: "Hi World" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { name: "Hi World" }, logger)).toEqual(false);
     });
 
     it("should match with operator: endsWith", function () {
@@ -66,11 +76,11 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { name: "Hello World" })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { name: "Hi World" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Hello World" }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Hi World" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { name: "Hi Universe" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { name: "Hi Universe" }, logger)).toEqual(false);
     });
 
     it("should match with operator: contains", function () {
@@ -83,11 +93,11 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { name: "Hello World" })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { name: "Yo! Hello!" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Hello World" }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Yo! Hello!" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { name: "Hi World" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { name: "Hi World" }, logger)).toEqual(false);
     });
 
     it("should match with operator: notContains", function () {
@@ -100,11 +110,11 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { name: "Hi World" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { name: "Hi World" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { name: "Hello World" })).toEqual(false);
-      expect(allConditionsAreMatched(conditions, { name: "Yo! Hello!" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { name: "Hello World" }, logger)).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { name: "Yo! Hello!" }, logger)).toEqual(false);
     });
 
     it("should match with operator: in", function () {
@@ -117,12 +127,16 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" }, logger)).toEqual(
+        true,
+      );
 
       // not match
-      expect(allConditionsAreMatched(conditions, { browser_type: "edge" })).toEqual(false);
-      expect(allConditionsAreMatched(conditions, { browser_type: "safari" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { browser_type: "edge" }, logger)).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { browser_type: "safari" }, logger)).toEqual(
+        false,
+      );
     });
 
     it("should match with operator: notIn", function () {
@@ -135,12 +149,16 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { browser_type: "edge" })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { browser_type: "safari" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { browser_type: "edge" }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { browser_type: "safari" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" })).toEqual(false);
-      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { browser_type: "chrome" }, logger)).toEqual(
+        false,
+      );
+      expect(allConditionsAreMatched(conditions, { browser_type: "firefox" }, logger)).toEqual(
+        false,
+      );
     });
 
     it("should match with operator: greaterThan", function () {
@@ -153,10 +171,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { age: 19 })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { age: 19 }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { age: 17 })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { age: 17 }, logger)).toEqual(false);
     });
 
     it("should match with operator: greaterThanOrEquals", function () {
@@ -169,12 +187,12 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { age: 18 })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { age: 19 })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { age: 18 }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { age: 19 }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { age: 17 })).toEqual(false);
-      expect(allConditionsAreMatched(conditions, { age: 16 })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { age: 17 }, logger)).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { age: 16 }, logger)).toEqual(false);
     });
 
     it("should match with operator: lessThan", function () {
@@ -187,10 +205,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { age: 17 })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { age: 17 }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { age: 19 })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { age: 19 }, logger)).toEqual(false);
     });
 
     it("should match with operator: lessThanOrEquals", function () {
@@ -203,12 +221,12 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { age: 17 })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { age: 18 })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { age: 17 }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { age: 18 }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { age: 19 })).toEqual(false);
-      expect(allConditionsAreMatched(conditions, { age: 20 })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { age: 19 }, logger)).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { age: 20 }, logger)).toEqual(false);
     });
 
     it("should match with operator: semverEquals", function () {
@@ -221,10 +239,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { version: "1.0.0" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "1.0.0" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { version: "2.0.0" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { version: "2.0.0" }, logger)).toEqual(false);
     });
 
     it("should match with operator: semverNotEquals", function () {
@@ -237,10 +255,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { version: "2.0.0" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "2.0.0" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { version: "1.0.0" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { version: "1.0.0" }, logger)).toEqual(false);
     });
 
     it("should match with operator: semverGreaterThan", function () {
@@ -253,10 +271,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { version: "2.0.0" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "2.0.0" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { version: "0.9.0" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { version: "0.9.0" }, logger)).toEqual(false);
     });
 
     it("should match with operator: semverGreaterThanOrEquals", function () {
@@ -269,11 +287,11 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { version: "1.0.0" })).toEqual(true);
-      expect(allConditionsAreMatched(conditions, { version: "2.0.0" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "1.0.0" }, logger)).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "2.0.0" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { version: "0.9.0" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { version: "0.9.0" }, logger)).toEqual(false);
     });
 
     it("should match with operator: semverLessThan", function () {
@@ -286,10 +304,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { version: "0.9.0" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "0.9.0" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { version: "1.1.0" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { version: "1.1.0" }, logger)).toEqual(false);
     });
 
     it("should match with operator: semverLessThanOrEquals", function () {
@@ -302,10 +320,10 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { version: "1.0.0" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { version: "1.0.0" }, logger)).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { version: "1.1.0" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { version: "1.1.0" }, logger)).toEqual(false);
     });
 
     it("should match with operator: before", function () {
@@ -318,15 +336,19 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { date: "2023-05-12T00:00:00Z" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { date: "2023-05-12T00:00:00Z" }, logger)).toEqual(
+        true,
+      );
       expect(
-        allConditionsAreMatched(conditions, { date: new Date("2023-05-12T00:00:00Z") }),
+        allConditionsAreMatched(conditions, { date: new Date("2023-05-12T00:00:00Z") }, logger),
       ).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { date: "2023-05-14T00:00:00Z" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { date: "2023-05-14T00:00:00Z" }, logger)).toEqual(
+        false,
+      );
       expect(
-        allConditionsAreMatched(conditions, { date: new Date("2023-05-14T00:00:00Z") }),
+        allConditionsAreMatched(conditions, { date: new Date("2023-05-14T00:00:00Z") }, logger),
       ).toEqual(false);
     });
 
@@ -340,15 +362,19 @@ describe("sdk: Conditions", function () {
       ];
 
       // match
-      expect(allConditionsAreMatched(conditions, { date: "2023-05-14T00:00:00Z" })).toEqual(true);
+      expect(allConditionsAreMatched(conditions, { date: "2023-05-14T00:00:00Z" }, logger)).toEqual(
+        true,
+      );
       expect(
-        allConditionsAreMatched(conditions, { date: new Date("2023-05-14T00:00:00Z") }),
+        allConditionsAreMatched(conditions, { date: new Date("2023-05-14T00:00:00Z") }, logger),
       ).toEqual(true);
 
       // not match
-      expect(allConditionsAreMatched(conditions, { date: "2023-05-12T00:00:00Z" })).toEqual(false);
+      expect(allConditionsAreMatched(conditions, { date: "2023-05-12T00:00:00Z" }, logger)).toEqual(
+        false,
+      );
       expect(
-        allConditionsAreMatched(conditions, { date: new Date("2023-05-12T00:00:00Z") }),
+        allConditionsAreMatched(conditions, { date: new Date("2023-05-12T00:00:00Z") }, logger),
       ).toEqual(false);
     });
   });
@@ -365,9 +391,13 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions[0], {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions[0],
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(true);
     });
 
@@ -382,9 +412,13 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(true);
     });
 
@@ -393,16 +427,24 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+          },
+          logger,
+        ),
       ).toEqual(true);
     });
 
@@ -417,10 +459,14 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "1.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "1.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
     });
 
@@ -440,11 +486,15 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "1.0",
-          foo: "bar",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "1.0",
+            foo: "bar",
+          },
+          logger,
+        ),
       ).toEqual(true);
     });
   });
@@ -465,16 +515,24 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
 
@@ -498,17 +556,25 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "1.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "1.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
   });
@@ -529,9 +595,13 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(true);
     });
 
@@ -555,16 +625,24 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_version: "1.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_version: "1.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
   });
@@ -585,16 +663,24 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
 
@@ -618,29 +704,45 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+          },
+          logger,
+        ),
       ).toEqual(true);
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "1.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "1.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
   });
@@ -675,31 +777,47 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "1.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "1.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "3.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "3.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
 
@@ -737,34 +855,50 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          country: "nl",
-          browser_type: "chrome",
-          browser_version: "1.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            country: "nl",
+            browser_type: "chrome",
+            browser_version: "1.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          country: "nl",
-          browser_type: "chrome",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            country: "nl",
+            browser_type: "chrome",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "3.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "3.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          country: "us",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            country: "us",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
 
@@ -797,33 +931,49 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "chrome",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "chrome",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-          device_type: "mobile",
-          orientation: "portrait",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+            device_type: "mobile",
+            orientation: "portrait",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-          device_type: "desktop",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+            device_type: "desktop",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
 
@@ -861,36 +1011,52 @@ describe("sdk: Conditions", function () {
 
       // match
       expect(
-        allConditionsAreMatched(conditions, {
-          country: "nl",
-          browser_type: "chrome",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            country: "nl",
+            browser_type: "chrome",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          country: "nl",
-          browser_type: "firefox",
-          device_type: "mobile",
-          orientation: "portrait",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            country: "nl",
+            browser_type: "firefox",
+            device_type: "mobile",
+            orientation: "portrait",
+          },
+          logger,
+        ),
       ).toEqual(true);
 
       // not match
       expect(
-        allConditionsAreMatched(conditions, {
-          browser_type: "firefox",
-          browser_version: "2.0",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            browser_type: "firefox",
+            browser_version: "2.0",
+          },
+          logger,
+        ),
       ).toEqual(false);
 
       expect(
-        allConditionsAreMatched(conditions, {
-          country: "de",
-          browser_type: "firefox",
-          device_type: "desktop",
-        }),
+        allConditionsAreMatched(
+          conditions,
+          {
+            country: "de",
+            browser_type: "firefox",
+            device_type: "desktop",
+          },
+          logger,
+        ),
       ).toEqual(false);
     });
   });

--- a/packages/sdk/src/conditions.ts
+++ b/packages/sdk/src/conditions.ts
@@ -2,6 +2,8 @@ import { compareVersions } from "compare-versions";
 
 import { Context, Condition, PlainCondition } from "@featurevisor/types";
 
+import { Logger } from "./logger";
+
 export function conditionIsMatched(condition: PlainCondition, context: Context): boolean {
   const { attribute, operator, value } = condition;
 
@@ -75,17 +77,30 @@ export function conditionIsMatched(condition: PlainCondition, context: Context):
 export function allConditionsAreMatched(
   conditions: Condition[] | Condition,
   context: Context,
+  logger: Logger,
 ): boolean {
   if ("attribute" in conditions) {
-    return conditionIsMatched(conditions, context);
+    try {
+      return conditionIsMatched(conditions, context);
+    } catch (e) {
+      logger.warn(e.message, {
+        error: e,
+        details: {
+          condition: conditions,
+          context,
+        },
+      });
+
+      return false;
+    }
   }
 
   if ("and" in conditions && Array.isArray(conditions.and)) {
-    return conditions.and.every((c) => allConditionsAreMatched(c, context));
+    return conditions.and.every((c) => allConditionsAreMatched(c, context, logger));
   }
 
   if ("or" in conditions && Array.isArray(conditions.or)) {
-    return conditions.or.some((c) => allConditionsAreMatched(c, context));
+    return conditions.or.some((c) => allConditionsAreMatched(c, context, logger));
   }
 
   if ("not" in conditions && Array.isArray(conditions.not)) {
@@ -96,12 +111,13 @@ export function allConditionsAreMatched(
             and: conditions.not,
           },
           context,
+          logger,
         ) === false,
     );
   }
 
   if (Array.isArray(conditions)) {
-    return conditions.every((c) => allConditionsAreMatched(c, context));
+    return conditions.every((c) => allConditionsAreMatched(c, context, logger));
   }
 
   return false;

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -2,6 +2,7 @@ import { Allocation, Context, Traffic, Feature, Force } from "@featurevisor/type
 import { DatafileReader } from "./datafileReader";
 import { allGroupSegmentsAreMatched } from "./segments";
 import { allConditionsAreMatched } from "./conditions";
+import { Logger } from "./logger";
 
 export function getMatchedAllocation(
   traffic: Traffic,
@@ -30,10 +31,16 @@ export function getMatchedTraffic(
   traffic: Traffic[],
   context: Context,
   datafileReader: DatafileReader,
+  logger: Logger,
 ): Traffic | undefined {
   return traffic.find((t) => {
     if (
-      !allGroupSegmentsAreMatched(parseFromStringifiedSegments(t.segments), context, datafileReader)
+      !allGroupSegmentsAreMatched(
+        parseFromStringifiedSegments(t.segments),
+        context,
+        datafileReader,
+        logger,
+      )
     ) {
       return false;
     }
@@ -52,12 +59,14 @@ export function getMatchedTrafficAndAllocation(
   context: Context,
   bucketValue: number,
   datafileReader: DatafileReader,
+  logger: Logger,
 ): MatchedTrafficAndAllocation {
   const matchedTraffic = traffic.find((t) => {
     return allGroupSegmentsAreMatched(
       parseFromStringifiedSegments(t.segments),
       context,
       datafileReader,
+      logger,
     );
   });
 
@@ -80,6 +89,7 @@ export function findForceFromFeature(
   feature: Feature,
   context: Context,
   datafileReader: DatafileReader,
+  logger: Logger,
 ): Force | undefined {
   if (!feature.force) {
     return undefined;
@@ -87,11 +97,11 @@ export function findForceFromFeature(
 
   return feature.force.find((f: Force) => {
     if (f.conditions) {
-      return allConditionsAreMatched(f.conditions, context);
+      return allConditionsAreMatched(f.conditions, context, logger);
     }
 
     if (f.segments) {
-      return allGroupSegmentsAreMatched(f.segments, context, datafileReader);
+      return allGroupSegmentsAreMatched(f.segments, context, datafileReader, logger);
     }
 
     return false;

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -521,7 +521,7 @@ export class FeaturevisorInstance {
       const finalContext = this.interceptContext ? this.interceptContext(context) : context;
 
       // forced
-      const force = findForceFromFeature(feature, context, this.datafileReader);
+      const force = findForceFromFeature(feature, context, this.datafileReader, this.logger);
 
       if (force && typeof force.enabled !== "undefined") {
         evaluation = {
@@ -579,7 +579,12 @@ export class FeaturevisorInstance {
       // bucketing
       const bucketValue = this.getBucketValue(feature, finalContext);
 
-      const matchedTraffic = getMatchedTraffic(feature.traffic, finalContext, this.datafileReader);
+      const matchedTraffic = getMatchedTraffic(
+        feature.traffic,
+        finalContext,
+        this.datafileReader,
+        this.logger,
+      );
 
       if (matchedTraffic) {
         // check if mutually exclusive
@@ -774,7 +779,7 @@ export class FeaturevisorInstance {
       const finalContext = this.interceptContext ? this.interceptContext(context) : context;
 
       // forced
-      const force = findForceFromFeature(feature, context, this.datafileReader);
+      const force = findForceFromFeature(feature, context, this.datafileReader, this.logger);
 
       if (force && force.variation) {
         const variation = feature.variations.find((v) => v.value === force.variation);
@@ -800,6 +805,7 @@ export class FeaturevisorInstance {
         finalContext,
         bucketValue,
         this.datafileReader,
+        this.logger,
       );
 
       if (matchedTraffic) {
@@ -1040,7 +1046,7 @@ export class FeaturevisorInstance {
       const finalContext = this.interceptContext ? this.interceptContext(context) : context;
 
       // forced
-      const force = findForceFromFeature(feature, context, this.datafileReader);
+      const force = findForceFromFeature(feature, context, this.datafileReader, this.logger);
 
       if (force && force.variables && typeof force.variables[variableKey] !== "undefined") {
         evaluation = {
@@ -1064,6 +1070,7 @@ export class FeaturevisorInstance {
         finalContext,
         bucketValue,
         this.datafileReader,
+        this.logger,
       );
 
       if (matchedTraffic) {
@@ -1109,6 +1116,7 @@ export class FeaturevisorInstance {
                     return allConditionsAreMatched(
                       typeof o.conditions === "string" ? JSON.parse(o.conditions) : o.conditions,
                       finalContext,
+                      this.logger,
                     );
                   }
 
@@ -1117,6 +1125,7 @@ export class FeaturevisorInstance {
                       parseFromStringifiedSegments(o.segments),
                       finalContext,
                       this.datafileReader,
+                      this.logger,
                     );
                   }
 

--- a/packages/sdk/src/segments.spec.ts
+++ b/packages/sdk/src/segments.spec.ts
@@ -1,6 +1,8 @@
+import { DatafileContent, GroupSegment } from "@featurevisor/types";
+
 import { DatafileReader } from "./datafileReader";
 import { allGroupSegmentsAreMatched } from "./segments";
-import { DatafileContent, GroupSegment } from "@featurevisor/types";
+import { createLogger } from "./logger";
 
 interface Group {
   key: string;
@@ -8,6 +10,8 @@ interface Group {
 }
 
 describe("sdk: Segments", function () {
+  const logger = createLogger();
+
   it("should be a function", function () {
     expect(typeof allGroupSegmentsAreMatched).toEqual("function");
   });
@@ -178,13 +182,13 @@ describe("sdk: Segments", function () {
       const group = groups.find((g) => g.key === "*") as Group;
 
       // match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(true);
-      expect(allGroupSegmentsAreMatched(group.segments, { foo: "foo" }, datafileReader)).toEqual(
-        true,
-      );
-      expect(allGroupSegmentsAreMatched(group.segments, { bar: "bar" }, datafileReader)).toEqual(
-        true,
-      );
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(true);
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { foo: "foo" }, datafileReader, logger),
+      ).toEqual(true);
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { bar: "bar" }, datafileReader, logger),
+      ).toEqual(true);
     });
 
     it("should match dutchMobileUsers", function () {
@@ -196,6 +200,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -203,16 +208,18 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(
           group.segments,
           { country: "de", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
     });
@@ -226,6 +233,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -233,16 +241,18 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(
           group.segments,
           { country: "de", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
     });
@@ -256,6 +266,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -263,6 +274,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -270,6 +282,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "desktop" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -277,16 +290,18 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "desktop", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(
           group.segments,
           { country: "de", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
       expect(
@@ -294,6 +309,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "de", deviceType: "desktop" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
     });
@@ -307,6 +323,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -314,6 +331,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "mobile", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -321,6 +339,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "desktop" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -328,16 +347,18 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "nl", deviceType: "desktop", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(
           group.segments,
           { country: "de", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
       expect(
@@ -345,6 +366,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "de", deviceType: "desktop" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
     });
@@ -358,6 +380,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "de", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -365,16 +388,18 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "de", deviceType: "mobile", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(
           group.segments,
           { country: "nl", deviceType: "mobile" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
     });
@@ -388,6 +413,7 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "de", deviceType: "desktop" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
       expect(
@@ -395,16 +421,18 @@ describe("sdk: Segments", function () {
           group.segments,
           { country: "de", deviceType: "desktop", browser: "chrome" },
           datafileReader,
+          logger,
         ),
       ).toEqual(true);
 
       // not match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(false);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(false);
       expect(
         allGroupSegmentsAreMatched(
           group.segments,
           { country: "nl", deviceType: "desktop" },
           datafileReader,
+          logger,
         ),
       ).toEqual(false);
     });
@@ -413,28 +441,28 @@ describe("sdk: Segments", function () {
       const group = groups.find((g) => g.key === "notVersion5.5") as Group;
 
       // match
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(true);
-      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader)).toEqual(true);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(true);
+      expect(allGroupSegmentsAreMatched(group.segments, {}, datafileReader, logger)).toEqual(true);
       expect(
-        allGroupSegmentsAreMatched(group.segments, { version: "5.6" }, datafileReader),
+        allGroupSegmentsAreMatched(group.segments, { version: "5.6" }, datafileReader, logger),
       ).toEqual(true);
-      expect(allGroupSegmentsAreMatched(group.segments, { version: 5.6 }, datafileReader)).toEqual(
-        true,
-      );
       expect(
-        allGroupSegmentsAreMatched(group.segments, { version: "5.7" }, datafileReader),
+        allGroupSegmentsAreMatched(group.segments, { version: 5.6 }, datafileReader, logger),
       ).toEqual(true);
-      expect(allGroupSegmentsAreMatched(group.segments, { version: 5.7 }, datafileReader)).toEqual(
-        true,
-      );
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { version: "5.7" }, datafileReader, logger),
+      ).toEqual(true);
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { version: 5.7 }, datafileReader, logger),
+      ).toEqual(true);
 
       // not match
       expect(
-        allGroupSegmentsAreMatched(group.segments, { version: "5.5" }, datafileReader),
+        allGroupSegmentsAreMatched(group.segments, { version: "5.5" }, datafileReader, logger),
       ).toEqual(false);
-      expect(allGroupSegmentsAreMatched(group.segments, { version: 5.5 }, datafileReader)).toEqual(
-        false,
-      );
+      expect(
+        allGroupSegmentsAreMatched(group.segments, { version: 5.5 }, datafileReader, logger),
+      ).toEqual(false);
     });
   });
 });

--- a/packages/sdk/src/segments.ts
+++ b/packages/sdk/src/segments.ts
@@ -1,15 +1,17 @@
 import { Context, GroupSegment, Segment, Condition } from "@featurevisor/types";
 import { allConditionsAreMatched } from "./conditions";
 import { DatafileReader } from "./datafileReader";
+import { Logger } from "./logger";
 
-export function segmentIsMatched(segment: Segment, context: Context): boolean {
-  return allConditionsAreMatched(segment.conditions as Condition | Condition[], context);
+export function segmentIsMatched(segment: Segment, context: Context, logger: Logger): boolean {
+  return allConditionsAreMatched(segment.conditions as Condition | Condition[], context, logger);
 }
 
 export function allGroupSegmentsAreMatched(
   groupSegments: GroupSegment | GroupSegment[] | "*",
   context: Context,
   datafileReader: DatafileReader,
+  logger: Logger,
 ): boolean {
   if (groupSegments === "*") {
     return true;
@@ -19,7 +21,7 @@ export function allGroupSegmentsAreMatched(
     const segment = datafileReader.getSegment(groupSegments);
 
     if (segment) {
-      return segmentIsMatched(segment, context);
+      return segmentIsMatched(segment, context, logger);
     }
 
     return false;
@@ -28,27 +30,27 @@ export function allGroupSegmentsAreMatched(
   if (typeof groupSegments === "object") {
     if ("and" in groupSegments && Array.isArray(groupSegments.and)) {
       return groupSegments.and.every((groupSegment) =>
-        allGroupSegmentsAreMatched(groupSegment, context, datafileReader),
+        allGroupSegmentsAreMatched(groupSegment, context, datafileReader, logger),
       );
     }
 
     if ("or" in groupSegments && Array.isArray(groupSegments.or)) {
       return groupSegments.or.some((groupSegment) =>
-        allGroupSegmentsAreMatched(groupSegment, context, datafileReader),
+        allGroupSegmentsAreMatched(groupSegment, context, datafileReader, logger),
       );
     }
 
     if ("not" in groupSegments && Array.isArray(groupSegments.not)) {
       return groupSegments.not.every(
         (groupSegment) =>
-          allGroupSegmentsAreMatched(groupSegment, context, datafileReader) === false,
+          allGroupSegmentsAreMatched(groupSegment, context, datafileReader, logger) === false,
       );
     }
   }
 
   if (Array.isArray(groupSegments)) {
     return groupSegments.every((groupSegment) =>
-      allGroupSegmentsAreMatched(groupSegment, context, datafileReader),
+      allGroupSegmentsAreMatched(groupSegment, context, datafileReader, logger),
     );
   }
 


### PR DESCRIPTION
## Background

- Featurevisor lets you define rules against environments for your features: https://featurevisor.com/docs/features/#rules
- Rules can have multiple segments defined: https://featurevisor.com/docs/features/#segments
- Segments are conditions against attributes, which may include semver operators: https://featurevisor.com/docs/segments/#semver-equals
- First rule that matches always wins during evaluation

## What's reproduced

When a wrong semver value is passed in context:

- SDK stops evaluating all further rules if parsing semver in current rule fails, and 
- returns `false` without crashing the app
- while logging the error to console

## What's expected

If semver value (even if it is in wrong format and) causes the parser to fail horribly, we want it to skip that rule and continue processing other rules in a sequential order.

Test specs have been written based on expectations, and they are failing right now (expected).

Once the fix is introduced in SDK, they will begin to pass.

## Where to fix?

It lies in SDK:

- Find occurrences of `allGroupSegmentsAreMatched` function in this file: https://github.com/featurevisor/featurevisor/blob/main/packages/sdk/src/feature.ts#L36
- When trying to match via `Array.find()`, if any of them fails:
  - log the error as a warning (for that, pass the `logger` instance to these functions from SDK instance first)
  - skip and move on to the next rule (if any)