### PR TITLE
GitHub Pages Setup Guide

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,6 +60,6 @@ If any of the steps above fail, the CI/CD pipeline should stop and notify the te
 
 ## Fully functional example
 
-You can refer to the CI/CD guide for [GitHub Actions](/docs/integrations/github-actions) and [Cloudflare Pages](/docs/integrations/cloudflare-pages) if you want a fully functional real-world example of setting up a Featurevisor project.
+You can refer to the CI/CD guide for [GitHub Actions](/docs/integrations/github-actions) and either [Cloudflare Pages](/docs/integrations/cloudflare-pages) or [GitHub Pages](/docs/integrations/github-pages) if you want a fully functional real-world example of setting up a Featurevisor project.
 
 Repo is available here: [https://github.com/featurevisor/featurevisor-example-cloudflare](https://github.com/featurevisor/featurevisor-example-cloudflare).

--- a/docs/integrations/cloudflare-pages.md
+++ b/docs/integrations/cloudflare-pages.md
@@ -147,7 +147,7 @@ jobs:
 
 After generating new datafiles and uploading them, the workflow will also take care of pushing the Featurevisor [state files](/docs/state-files) back to the repository, so that future builds will be built on top of latest state.
 
-Once uploaded, the your datafiles will be accessible as: `https://<your-project>.pages.dev/<environment>/datafile-tag-<your-tag>.json`.
+Once uploaded, your datafiles will be accessible as: `https://<your-project>.pages.dev/<environment>/datafile-tag-<your-tag>.json`.
 
 You may want to take it a step further by setting up custom domains (or subdomains) for your Cloudflare Pages project. Otherwise, you are good to go.
 

--- a/docs/integrations/github-pages.md
+++ b/docs/integrations/github-pages.md
@@ -163,3 +163,7 @@ Learn how to consume datafiles from URLs directly using [SDKs](/docs/sdks).
 ## Full example
 
 You can find a fully functional repository based on this guide here: [https://github.com/meirroth/featurevisor-example-github](https://github.com/meirroth/featurevisor-example-github).
+
+## Sequential builds
+
+In case you are worried about simultaneous builds triggered by multiple Pull Requests merged in quick succession, you can learn about mitigating any unintended issues [here](/docs/integrations/github-actions/#sequential-builds).

--- a/docs/integrations/github-pages.md
+++ b/docs/integrations/github-pages.md
@@ -1,0 +1,165 @@
+---
+title: GitHub Pages
+description: Learn how to upload Featurevisor datafiles to GitHub Pages
+# TODO: Fix image
+ogImage: /img/og/docs-integrations-github-pages.png
+---
+
+Set up continuous integration and deployment of your Feaurevisor project with GitHub Actions and GitHub Pages. {% .lead %}
+
+See more about GitHub Actions set up in previous guide [here](/docs/integrations/github-actions).
+
+## Creating a new project
+
+This guide assumes you have created a new Featurevisor project using the CLI:
+
+```
+$ mkdir my-featurevisor-project && cd my-featurevisor-project
+
+$ npx @featurevisor/cli init
+$ npm install
+```
+
+## GitHub Pages
+
+We are going to be uploading to and serving our datafiles from [GitHub Pages](https://pages.github.com/).
+
+GitHub Pages is a product that allows you to host your static sites and apps on GitHub's global network. Given Featurevisor project generates static datafiles (JSON files), it is a great fit for our use case.
+
+## Workflows
+
+We will be covering two workflows for our set up with GitHub Actions.
+
+### Checks
+
+This workflow will be triggered on every push to the repository targeting any non-master or non-main branches.
+
+This will help identify any issues with your Pull Requests early before you merge them to your main branch.
+
+```yml
+# .github/workflows/checks.yml
+name: Checks
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - master
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx featurevisor lint
+
+      - name: Test specs
+        run: npx featurevisor test
+
+      - name: Build
+        run: npx featurevisor build
+```
+
+### Publish
+
+This workflow is intended to be run on every push to your main (or master) branch, and is supposed to handle publishing your generated datafiles to GitHub Pages:
+
+```yml
+# .github/workflows/publish.yml
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx featurevisor lint
+
+      - name: Test specs
+        run: npx featurevisor test
+
+      - name: Build
+        run: npx featurevisor build
+
+      - name: Create index.html
+        run: echo "<html><body>It works.</body></html>" > dist/index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Git configs
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Push back to origin
+        run: |
+          git add .featurevisor/*
+          git commit -m "[skip ci] Revision $(cat .featurevisor/REVISION)"
+          git push
+```
+
+After generating new datafiles and uploading them, the workflow will also take care of pushing the Featurevisor [state files](/docs/state-files) back to the repository, so that future builds will be built on top of latest state.
+
+Once uploaded, your datafiles will be accessible as: `https://<username>.github.io/<repo>/<environment>/datafile-tag-<your-tag>.json`.
+
+You may want to take it a step further by [setting up custom domains (or subdomains)](https://docs.github.com/articles/using-a-custom-domain-with-github-pages/) for your GitHub Pages project. Otherwise, you are good to go.
+
+Learn how to consume datafiles from URLs directly using [SDKs](/docs/sdks).
+
+## Full example
+
+You can find a fully functional repository based on this guide here: [https://github.com/meirroth/featurevisor-example-github](https://github.com/meirroth/featurevisor-example-github).

--- a/docs/sidebarNavigation.json
+++ b/docs/sidebarNavigation.json
@@ -91,6 +91,7 @@
     "title": "CI/CD guides",
     "links": [
       { "title": "GitHub Actions", "href": "/docs/integrations/github-actions" },
+      { "title": "GitHub Pages", "href": "/docs/integrations/github-pages" },
       { "title": "Cloudflare Pages", "href": "/docs/integrations/cloudflare-pages" },
       { "title": "PartyKit", "href": "/docs/integrations/partykit" }
     ]


### PR DESCRIPTION
Hi @fahad19,

I've been working on a new guide for setting up Featurevisor with GitHub Pages and I think it's ready to be shared with the world. This guide walks you through the process of setting up continuous integration and deployment of your Featurevisor project with GitHub Actions and GitHub Pages.

Why GitHub Pages, you ask? Well, it's a great alternative to the Cloudflare setup. Not everyone has a Cloudflare account, and not everyone wants to manage one. GitHub Pages, on the other hand, is available to all GitHub users, so it's a bit more accessible. Plus, you don't have to manage environment secrets, which is a nice bonus.

I've also made sure to streamline the process as much as possible. For example, I've removed the "Sequential builds" step from the Cloudflare guide because it's already handled by the concurrency setting in the publish.yml file. Similarly, the "Repository settings" step is taken care of by the permissions setting in the same file.

I believe this guide will be a valuable addition to the documentation. It provides an alternative setup process that some users may find easier or more convenient. I suggest we link this guide before the Cloudflare doc page in the sidebar to give it a bit more visibility.

You can check out the new guide in the github-pages.md file in this PR. Let me know what you think!

You can find a fully functional repository based on this guide here: [https://github.com/meirroth/featurevisor-example-github](https://github.com/meirroth/featurevisor-example-github) (I can transfer this repo to the featurevisor org if you'd like)
And live deploy at https://meirroth.github.io/featurevisor-example-github/production/datafile-tag-all.json

Cheers!