### PR TITLE
feat: introduce new project config stringify

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,14 @@ Set to `true` or `false` to enable or disable pretty-printing of datafiles.
 
 Defaults to `false`.
 
+### `stringify`
+
+By default, Featurevisor will stringify conditions and segments in generated datafiles so that they are parsed only when needed by the SDKs. This optimization technique works well when datafiles are too large in client-side devices (think browsers) and you are only dealing with one user in the runtime.
+
+This kind of optimization though can bring opposite results if you are using the SDKs in server-side (think Node.js) serving many different users.
+
+To disable this stringification, you can set it to `false`.
+
 ### `parser`
 
 By default, Featurevisor expects YAML for all definitions. You can change this to JSON by setting `parser: "json"`.

--- a/examples/example-1/featurevisor.config.js
+++ b/examples/example-1/featurevisor.config.js
@@ -3,4 +3,5 @@ module.exports = {
   environments: ["staging", "production"],
   tags: ["all", "checkout"],
   prettyState: true,
+  prettyDatafile: true,
 };

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -159,7 +159,9 @@ export async function buildDatafile(
                     );
 
                     return {
-                      conditions: JSON.stringify(override.conditions),
+                      conditions: projectConfig.stringify
+                        ? JSON.stringify(override.conditions)
+                        : override.conditions,
                       value: override.value,
                     };
                   }
@@ -174,9 +176,9 @@ export async function buildDatafile(
 
                     return {
                       segments:
-                        typeof override.segments === "string"
-                          ? override.segments
-                          : JSON.stringify(override.segments),
+                        typeof override.segments !== "string" && projectConfig.stringify
+                          ? JSON.stringify(override.segments)
+                          : override.segments,
                       value: override.value,
                     };
                   }
@@ -195,7 +197,15 @@ export async function buildDatafile(
           parsedFeature.environments[options.environment].rules,
           existingState.features[featureKey],
           featureRanges.get(featureKey) || [],
-        ),
+        ).map((t: Traffic) => {
+          return {
+            ...t,
+            segments:
+              typeof typeof t.segments !== "string" && projectConfig.stringify
+                ? JSON.stringify(t.segments)
+                : t.segments,
+          };
+        }),
         ranges: featureRanges.get(featureKey) || undefined,
       };
 
@@ -278,7 +288,7 @@ export async function buildDatafile(
       const segment: Segment = {
         key: segmentKey,
         conditions:
-          typeof parsedSegment.conditions !== "string"
+          typeof parsedSegment.conditions !== "string" && projectConfig.stringify === true
             ? JSON.stringify(parsedSegment.conditions)
             : parsedSegment.conditions,
       };

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -201,7 +201,7 @@ export async function buildDatafile(
           return {
             ...t,
             segments:
-              typeof typeof t.segments !== "string" && projectConfig.stringify
+              typeof t.segments !== "string" && projectConfig.stringify
                 ? JSON.stringify(t.segments)
                 : t.segments,
           };

--- a/packages/core/src/builder/traffic.ts
+++ b/packages/core/src/builder/traffic.ts
@@ -79,11 +79,8 @@ export function getTraffic(
     const rulePercentage = parsedRule.percentage; // 0 - 100
 
     const traffic: Traffic = {
-      key: parsedRule.key, // @TODO: not needed in datafile. keep it for now
-      segments:
-        typeof parsedRule.segments !== "string"
-          ? JSON.stringify(parsedRule.segments)
-          : parsedRule.segments,
+      key: parsedRule.key,
+      segments: parsedRule.segments,
       percentage: rulePercentage * (MAX_BUCKETED_NUMBER / 100),
       allocation: [],
     };

--- a/packages/core/src/config/projectConfig.ts
+++ b/packages/core/src/config/projectConfig.ts
@@ -42,6 +42,7 @@ export interface ProjectConfig {
   parser: Parser;
   prettyState: boolean;
   prettyDatafile: boolean;
+  stringify: boolean;
   siteExportDirectoryPath: string;
   adapter: any; // @TODO: type this properly later
 }
@@ -66,6 +67,7 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
 
     prettyState: DEFAULT_PRETTY_STATE,
     prettyDatafile: DEFAULT_PRETTY_DATAFILE,
+    stringify: true,
 
     siteExportDirectoryPath: path.join(rootDirectoryPath, SITE_EXPORT_DIRECTORY_NAME),
 
@@ -78,7 +80,8 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
   const mergedConfig = {};
 
   Object.keys(baseConfig).forEach((key) => {
-    mergedConfig[key] = customConfig[key] || baseConfig[key];
+    mergedConfig[key] =
+      typeof customConfig[key] !== "undefined" ? customConfig[key] : baseConfig[key];
 
     if (key.endsWith("Path") && mergedConfig[key].indexOf(ROOT_DIR_PLACEHOLDER) !== -1) {
       mergedConfig[key] = mergedConfig[key].replace(ROOT_DIR_PLACEHOLDER, rootDirectoryPath);


### PR DESCRIPTION
## What's done

More info in docs (see diff).

A new optional `stringify` property introduced in project configuration for controlling the stringification behaviour of segments and conditions in generated datafiles.

```js
// featurevisor.config.js
module.exports = {
  environments: ["staging", "production"],
  tags: ["web", "ios", "android"],

  // optional
  stringify: false // true by default
};
```