### PR TITLE
feat: benchmarking option in CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -147,3 +147,47 @@ $ npx featurevisor find-usage --unusedSegments
 ```
 $ npx featurevisor find-usage --unusedAttributes
 ```
+
+## Benchmarking
+
+You can measure how fast or slow your SDK evaluations are for particular features.
+
+The `--n` option is used to specify the number of iterations to run the benchmark for.
+
+### Feature
+
+To benchmark evaluating a feature itself if it is enabled or disabled via SDK's `.isEnabled()` method:
+
+```
+$ npx featurevisor benchmark \
+  --environment=production \
+  --feature=my_feature \
+  --context='{"userId": "123"}' \
+  --n=1000
+```
+
+### Variation
+
+To benchmark evaluating a feature's variation via SDKs's `.getVariation()` method:
+
+```
+$ npx featurevisor benchmark \
+  --environment=production \
+  --feature=my_feature \
+  --variation \
+  --context='{"userId": "123"}' \
+  --n=1000
+```
+
+### Variable
+
+To benchmark evaluating a feature's variable via SDKs's `.getVariable()` method:
+
+```
+$ npx featurevisor benchmark \
+  --environment=production \
+  --feature=my_feature \
+  --variable=my_variable_key \
+  --context='{"userId": "123"}' \
+  --n=1000
+```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import {
   restoreProject,
   Dependencies,
   Datasource,
+  benchmarkFeature,
 } from "@featurevisor/core";
 
 process.on("unhandledRejection", (reason) => {
@@ -260,6 +261,53 @@ async function main() {
     .example("$0 find-usage --attribute=my_attribute", "find usage of attribute")
     .example("$0 find-usage --unusedSegments", "find unused segments")
     .example("$0 find-usage --unusedAttributes", "find unused attributes")
+
+    /**
+     * Benchmark features
+     */
+    .command({
+      command: "benchmark",
+      handler: async function (options) {
+        if (!options.environment) {
+          console.error("Please specify an environment with --environment flag.");
+          process.exit(1);
+        }
+
+        if (!options.feature) {
+          console.error("Please specify a feature with --feature flag.");
+          process.exit(1);
+        }
+
+        const deps = await getDependencies(options);
+
+        try {
+          await benchmarkFeature(deps, {
+            environment: options.environment,
+            feature: options.feature,
+            n: parseInt(options.n, 10) || 1,
+            context: options.context ? JSON.parse(options.context) : {},
+            variation: options.variation || undefined,
+            variable: options.variable || undefined,
+          });
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1);
+        }
+      },
+    })
+    .example("$0 benchmark", "benchmark feature evaluations")
+    .example(
+      "$0 benchmark --environment=production --feature=my_feature --context='{}' -n=100",
+      "benchmark feature flag evaluation",
+    )
+    .example(
+      "$0 benchmark --environment=production --feature=my_feature --context='{}' --variation -n=100",
+      "benchmark feature variation evaluation",
+    )
+    .example(
+      "$0 benchmark --environment=production --feature=my_feature --context='{}' --variable=my_variable_key -n=100",
+      "benchmark feature variable evaluation",
+    )
 
     /**
      * Options

--- a/packages/core/src/benchmark/index.ts
+++ b/packages/core/src/benchmark/index.ts
@@ -1,0 +1,150 @@
+import { Context } from "@featurevisor/types";
+import { FeaturevisorInstance, createInstance } from "@featurevisor/sdk";
+
+import { SCHEMA_VERSION } from "../config";
+import { buildDatafile } from "../builder";
+import { Dependencies } from "../dependencies";
+import { prettyDuration } from "../tester/prettyDuration";
+
+export interface BenchmarkOutput {
+  value: any;
+  duration: number; // ms
+}
+
+export function benchmarkFeatureFlag(
+  f: FeaturevisorInstance,
+  featureKey: string,
+  context: Record<string, unknown>,
+  n: number,
+): BenchmarkOutput {
+  const start = Date.now();
+  let value: any;
+
+  for (let i = 0; i < n; i++) {
+    value = f.isEnabled(featureKey, context as Context);
+  }
+
+  const duration = Date.now() - start;
+
+  return {
+    value,
+    duration,
+  };
+}
+
+export function benchmarkFeatureVariation(
+  f: FeaturevisorInstance,
+  featureKey: string,
+  context: Record<string, unknown>,
+  n: number,
+): BenchmarkOutput {
+  const start = Date.now();
+  let value: any;
+
+  for (let i = 0; i < n; i++) {
+    value = f.getVariation(featureKey, context as Context);
+  }
+
+  const duration = Date.now() - start;
+
+  return {
+    value,
+    duration,
+  };
+}
+
+export function benchmarkFeatureVariable(
+  f: FeaturevisorInstance,
+  featureKey: string,
+  variableKey: string,
+  context: Record<string, unknown>,
+  n: number,
+): BenchmarkOutput {
+  const start = Date.now();
+  let value: any;
+
+  for (let i = 0; i < n; i++) {
+    value = f.getVariable(featureKey, variableKey, context as Context);
+  }
+
+  const duration = Date.now() - start;
+
+  return {
+    value,
+    duration,
+  };
+}
+
+export interface BenchmarkOptions {
+  environment: string;
+  feature: string;
+  n: number;
+  context: Record<string, unknown>;
+  variation?: boolean;
+  variable?: string;
+}
+
+export async function benchmarkFeature(
+  deps: Dependencies,
+  options: BenchmarkOptions,
+): Promise<void> {
+  const { datasource, projectConfig } = deps;
+
+  console.log("");
+  console.log(`Running benchmark for feature "${options.feature}"...`);
+
+  console.log("");
+
+  console.log(`Building datafile containing all features for "${options.environment}"...`);
+  const datafileBuildStart = Date.now();
+  const existingState = await datasource.readState(options.environment);
+  const datafileContent = await buildDatafile(
+    projectConfig,
+    datasource,
+    {
+      schemaVersion: SCHEMA_VERSION,
+      revision: "include-all-features",
+      environment: options.environment,
+    },
+    existingState,
+  );
+  const datafileBuildDuration = Date.now() - datafileBuildStart;
+  console.log(`Datafile build duration: ${datafileBuildDuration}ms`);
+
+  console.log("");
+
+  const f = createInstance({
+    datafile: datafileContent,
+  });
+  console.log("...SDK initialized");
+
+  console.log("");
+  console.log(`Against context: ${JSON.stringify(options.context)}`);
+
+  let output: BenchmarkOutput;
+  if (options.variable) {
+    // variable
+    console.log(`Evaluating variable "${options.variable}" ${options.n} times...`);
+    output = benchmarkFeatureVariable(
+      f,
+      options.feature,
+      options.variable,
+      options.context,
+      options.n,
+    );
+  } else if (options.variation) {
+    // variation
+    console.log(`Evaluating variation ${options.n} times...`);
+    output = benchmarkFeatureVariation(f, options.feature, options.context, options.n);
+  } else {
+    // flag
+    console.log(`Evaluating flag ${options.n} times...`);
+    output = benchmarkFeatureFlag(f, options.feature, options.context, options.n);
+  }
+
+  console.log("");
+
+  console.log(`Evaluated value : ${JSON.stringify(output.value)}`);
+  console.log(`Total duration  : ${prettyDuration(output.duration)}`);
+  console.log(`Average duration: ${prettyDuration(output.duration / options.n)}`);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,3 +10,4 @@ export * from "./find-duplicate-segments";
 export * from "./find-usage";
 export * from "./dependencies";
 export * from "./datasource";
+export * from "./benchmark";


### PR DESCRIPTION
## What's done

Introduced an option to benchmark feature/variation/variable evaluations from CLI.

## API

Read more in docs (in diff).

To run benchmarking for a feature:

```
$ npx featurevisor benchmark \
  --environment=production \
  --feature=foo \
  --context='{"country":"de","userId":"123","device":"mobile"}' \
  --n=1000000
```

Output will be similar to this:

```
Running benchmark for feature "foo"...

Building datafile containing all features for "production"...
Datafile build duration: 16ms

...SDK initialized

Against context: {"country":"de","userId":"123","device":"mobile"}
Evaluating flag 1000000 times...

Evaluated value : true
Total duration  : 1s 992ms
Average duration: 0.001992ms
```