### PR TITLE
feat: show project configuration via CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,3 +191,17 @@ $ npx featurevisor benchmark \
   --context='{"userId": "123"}' \
   --n=1000
 ```
+
+## Configuration
+
+To view the project [configuration](/docs/configuration):
+
+```
+$ npx featurevisor config
+```
+
+Printing configuration as JSON:
+
+```
+$ npx featurevisor config --print --pretty
+```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import {
   Dependencies,
   Datasource,
   benchmarkFeature,
+  showProjectConfig,
 } from "@featurevisor/core";
 
 process.on("unhandledRejection", (reason) => {
@@ -308,6 +309,24 @@ async function main() {
       "$0 benchmark --environment=production --feature=my_feature --context='{}' --variable=my_variable_key -n=100",
       "benchmark feature variable evaluation",
     )
+
+    /**
+     * Show config
+     */
+    .command({
+      command: "config",
+      handler: async function (options) {
+        const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
+
+        showProjectConfig(projectConfig, {
+          print: options.print,
+          pretty: options.pretty,
+        });
+      },
+    })
+    .example("$0 config", "show project configuration")
+    .example("$0 config --print", "print project configuration as JSON")
+    .example("$0 config --print --pretty", "print project configuration as prettified JSON")
 
     /**
      * Options

--- a/packages/core/src/config/projectConfig.ts
+++ b/packages/core/src/config/projectConfig.ts
@@ -50,15 +50,6 @@ export interface ProjectConfig {
 // rootDirectoryPath: path to the root directory of the project (without ending with a slash)
 export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
   const baseConfig: ProjectConfig = {
-    featuresDirectoryPath: path.join(rootDirectoryPath, FEATURES_DIRECTORY_NAME),
-    segmentsDirectoryPath: path.join(rootDirectoryPath, SEGMENTS_DIRECTORY_NAME),
-    attributesDirectoryPath: path.join(rootDirectoryPath, ATTRIBUTES_DIRECTORY_NAME),
-    groupsDirectoryPath: path.join(rootDirectoryPath, GROUPS_DIRECTORY_NAME),
-    testsDirectoryPath: path.join(rootDirectoryPath, TESTS_DIRECTORY_NAME),
-
-    stateDirectoryPath: path.join(rootDirectoryPath, STATE_DIRECTORY_NAME),
-    outputDirectoryPath: path.join(rootDirectoryPath, OUTPUT_DIRECTORY_NAME),
-
     environments: DEFAULT_ENVIRONMENTS,
     tags: DEFAULT_TAGS,
     defaultBucketBy: "userId",
@@ -69,9 +60,16 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
     prettyDatafile: DEFAULT_PRETTY_DATAFILE,
     stringify: true,
 
-    siteExportDirectoryPath: path.join(rootDirectoryPath, SITE_EXPORT_DIRECTORY_NAME),
-
     adapter: FilesystemAdapter,
+
+    featuresDirectoryPath: path.join(rootDirectoryPath, FEATURES_DIRECTORY_NAME),
+    segmentsDirectoryPath: path.join(rootDirectoryPath, SEGMENTS_DIRECTORY_NAME),
+    attributesDirectoryPath: path.join(rootDirectoryPath, ATTRIBUTES_DIRECTORY_NAME),
+    groupsDirectoryPath: path.join(rootDirectoryPath, GROUPS_DIRECTORY_NAME),
+    testsDirectoryPath: path.join(rootDirectoryPath, TESTS_DIRECTORY_NAME),
+    stateDirectoryPath: path.join(rootDirectoryPath, STATE_DIRECTORY_NAME),
+    outputDirectoryPath: path.join(rootDirectoryPath, OUTPUT_DIRECTORY_NAME),
+    siteExportDirectoryPath: path.join(rootDirectoryPath, SITE_EXPORT_DIRECTORY_NAME),
   };
 
   const configModulePath = path.join(rootDirectoryPath, CONFIG_MODULE_NAME);
@@ -100,4 +98,37 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
   }
 
   return finalConfig as ProjectConfig;
+}
+
+export interface ShowProjectConfigOptions {
+  print?: boolean;
+  pretty?: boolean;
+}
+
+export function showProjectConfig(
+  projectConfig: ProjectConfig,
+  options: ShowProjectConfigOptions = {},
+) {
+  const keys = Object.keys(projectConfig);
+
+  if (options.print) {
+    console.log(
+      options.pretty ? JSON.stringify(projectConfig, null, 2) : JSON.stringify(projectConfig),
+    );
+
+    return;
+  }
+
+  console.log("\nProject configuration:\n");
+
+  const longestKeyLength = keys.reduce((acc, key) => (key.length > acc ? key.length : acc), 0);
+  const ignoreKeys = ["adapter", "parser"];
+
+  for (const key of keys) {
+    if (ignoreKeys.indexOf(key) !== -1) {
+      continue;
+    }
+
+    console.log(`  - ${key.padEnd(longestKeyLength, " ")}: ${projectConfig[key]}`);
+  }
 }


### PR DESCRIPTION
## What's done

New command available for showing project configuration:

```
$ npx featurevisor config
```

To print as JSON:

```
$ npx featurevisor config --print --pretty
```

## Why?

As we have more SDKs and Test Runners in different programming languages, not everyone can make sense of the configuration as exists in `featurevisor.config.js` file: https://featurevisor.com/docs/configuration/

With this command, we are now enabling others to read this configuration in plain JSON if they need to.