### PR TITLE
feat: evaluate features in CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,3 +205,31 @@ Printing configuration as JSON:
 ```
 $ npx featurevisor config --print --pretty
 ```
+
+## Evaluate
+
+To learn why certain values (like feature and its variation or variables) are evaluated as they are:
+
+```
+$ npx featurevisor evaluate \
+  --environment=production \
+  --feature=my_feature \
+  --context='{"userId": "123", "country": "nl"}'
+```
+
+This will show you full [evaluation details](/docs/sdks/javascript/#evaluation-details) helping you debug better in case of any confusion.
+
+It is similar to [logging](/docs/sdks/javascript/#logging) in SDKs with `debug` level. But here instead, we are doing it at CLI directly in our Featurevisor project without having to involve our application(s).
+
+If you wish to print the evaluation details in plain JSON, you can pass `--print` at the end:
+
+```
+$ npx featurevisor evaluate \
+  --environment=production \
+  --feature=my_feature \
+  --context='{"userId": "123", "country": "nl"}' \
+  --print \
+  --pretty
+```
+
+The `--pretty` flag is optional.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import {
   Datasource,
   benchmarkFeature,
   showProjectConfig,
+  evaluateFeature,
 } from "@featurevisor/core";
 
 process.on("unhandledRejection", (reason) => {
@@ -327,6 +328,44 @@ async function main() {
     .example("$0 config", "show project configuration")
     .example("$0 config --print", "print project configuration as JSON")
     .example("$0 config --print --pretty", "print project configuration as prettified JSON")
+
+    /**
+     * Evaluate
+     */
+    .command({
+      command: "evaluate",
+      handler: async function (options) {
+        if (!options.environment) {
+          console.error("Please specify an environment with --environment flag.");
+          process.exit(1);
+        }
+
+        if (!options.feature) {
+          console.error("Please specify a feature with --feature flag.");
+          process.exit(1);
+        }
+
+        const deps = await getDependencies(options);
+
+        try {
+          await evaluateFeature(deps, {
+            environment: options.environment,
+            feature: options.feature,
+            context: options.context ? JSON.parse(options.context) : {},
+            print: options.print,
+            pretty: options.pretty,
+          });
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1);
+        }
+      },
+    })
+    .example("$0 evaluate", "evaluate a feature along with its variation and variables")
+    .example(
+      "$0 evaluate --environment=production --feature=my_feature --context='{}'",
+      "evaluate a feature against provided context",
+    )
 
     /**
      * Options

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -6,7 +6,7 @@ import { SCHEMA_VERSION } from "../config";
 import { buildDatafile } from "../builder";
 
 function printEvaluationDetails(evaluation: Evaluation) {
-  const ignoreKeys = ["featureKey", "traffic", "force"];
+  const ignoreKeys = ["featureKey", "variableKey", "traffic", "force"];
 
   for (const [key, value] of Object.entries(evaluation)) {
     if (ignoreKeys.indexOf(key) !== -1) {

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -18,6 +18,12 @@ function printEvaluationDetails(evaluation: Evaluation) {
       continue;
     }
 
+    if (key === "variableSchema") {
+      console.log(`-`, `variableType:`, value.type);
+      console.log(`-`, `defaultValue:`, value.defaultValue);
+      continue;
+    }
+
     console.log(`-`, `${key}:`, value);
   }
 }
@@ -68,7 +74,7 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
 
   const flagEvaluation = f.evaluateFlag(options.feature, options.context as Context);
   const variationEvaluation = f.evaluateVariation(options.feature, options.context as Context);
-  const variableEvaluations: Array<Evaluation> = [];
+  const variableEvaluations: Record<string, Evaluation> = {};
 
   const feature = f.getFeature(options.feature);
   if (feature?.variablesSchema) {
@@ -78,7 +84,7 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
         v.key,
         options.context as Context,
       );
-      variableEvaluations.push(variableEvaluation);
+      variableEvaluations[v.key] = variableEvaluation;
     });
   }
 
@@ -117,6 +123,22 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
 
     printEvaluationDetails(variationEvaluation);
   } else {
-    console.log("No variations available.");
+    console.log("No variations defined.");
+  }
+
+  // variables
+  if (feature?.variablesSchema) {
+    for (const [key, value] of Object.entries(variableEvaluations)) {
+      printHeader(`Variable: ${key}`);
+
+      console.log("Value:", value.variableValue);
+      console.log("\nDetails:\n");
+
+      printEvaluationDetails(value);
+    }
+  } else {
+    printHeader("Variables");
+
+    console.log("No variables defined.");
   }
 }

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -6,7 +6,7 @@ import { SCHEMA_VERSION } from "../config";
 import { buildDatafile } from "../builder";
 
 function printEvaluationDetails(evaluation: Evaluation) {
-  const ignoreKeys = ["featureKey", "traffic"];
+  const ignoreKeys = ["featureKey", "traffic", "force"];
 
   for (const [key, value] of Object.entries(evaluation)) {
     if (ignoreKeys.indexOf(key) !== -1) {
@@ -14,7 +14,7 @@ function printEvaluationDetails(evaluation: Evaluation) {
     }
 
     if (key === "variation") {
-      console.log(`-`, `${key}:`, value?.key);
+      console.log(`-`, `${key}:`, value?.value);
       continue;
     }
 
@@ -118,7 +118,7 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
   printHeader("Variation");
 
   if (feature?.variations) {
-    console.log("Value:", variationEvaluation.enabled);
+    console.log("Value:", variationEvaluation.variation?.value);
     console.log("\nDetails:\n");
 
     printEvaluationDetails(variationEvaluation);

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -1,0 +1,110 @@
+import { Context } from "@featurevisor/types";
+import { Evaluation, createInstance, createLogger } from "@featurevisor/sdk";
+
+import { Dependencies } from "../dependencies";
+import { SCHEMA_VERSION } from "../config";
+import { buildDatafile } from "../builder";
+import { prettyNumber } from "../utils";
+
+export interface EvaluateOptions {
+  environment: string;
+  feature: string;
+  context: Record<string, unknown>;
+  print?: boolean;
+  pretty?: boolean;
+}
+
+export async function evaluateFeature(deps: Dependencies, options: EvaluateOptions) {
+  const { datasource, projectConfig } = deps;
+
+  const existingState = await datasource.readState(options.environment);
+  const datafileContent = await buildDatafile(
+    projectConfig,
+    datasource,
+    {
+      schemaVersion: SCHEMA_VERSION,
+      revision: "include-all-features",
+      environment: options.environment,
+    },
+    existingState,
+  );
+
+  const logs: Array<any> = [];
+  const f = createInstance({
+    datafile: datafileContent,
+    logger: createLogger({
+      levels: ["error", "warn", "info", "debug"],
+      handler: (level, message, details) => {
+        logs.push({
+          level,
+          message,
+          details,
+        });
+      },
+    }),
+  });
+
+  const flagEvaluation = f.evaluateFlag(options.feature, options.context as Context);
+  const variationEvaluation = f.evaluateVariation(options.feature, options.context as Context);
+  const variableEvaluations: Array<Evaluation> = [];
+
+  const feature = f.getFeature(options.feature);
+  if (feature?.variablesSchema) {
+    feature.variablesSchema.forEach((v) => {
+      const variableEvaluation = f.evaluateVariable(
+        options.feature,
+        v.key,
+        options.context as Context,
+      );
+      variableEvaluations.push(variableEvaluation);
+    });
+  }
+
+  const allEvaluations = {
+    flag: flagEvaluation,
+    variation: variationEvaluation,
+    variables: variableEvaluations,
+  };
+
+  if (options.print) {
+    console.log(
+      options.pretty ? JSON.stringify(allEvaluations, null, 2) : JSON.stringify(allEvaluations),
+    );
+
+    return;
+  }
+
+  console.log("");
+  console.log(`Evaluating feature "${options.feature}" in environment "${options.environment}..."`);
+  console.log(`Against context: ${JSON.stringify(options.context)}`);
+
+  // flag
+  console.log("\n###");
+  console.log("# Is enabled?");
+  console.log("#\n");
+
+  console.log("Value:", flagEvaluation.enabled);
+  console.log("\nDetails:");
+
+  for (const [key, value] of Object.entries(flagEvaluation)) {
+    if (key === "traffic") {
+      continue;
+    }
+
+    console.log(`-`, `${key}:`, value);
+  }
+
+  // const variation = f.getVariation(options.feature, options.context as Context);
+  // console.log("Variation:", variation);
+
+  // const feature = f.getFeature(options.feature);
+
+  // if (feature?.variablesSchema) {
+  //   console.log("Variables:");
+
+  //   feature.variablesSchema.forEach((v) => {
+  //     const variableValue = f.getVariable(options.feature, v.key, options.context as Context);
+  //     console.log(`  - "${v.key}": ${variableValue}`);
+  //   });
+  // }
+}

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -6,7 +6,7 @@ import { SCHEMA_VERSION } from "../config";
 import { buildDatafile } from "../builder";
 
 function printEvaluationDetails(evaluation: Evaluation) {
-  const ignoreKeys = ["featureKey", "traffic", "bucketValue", "bucketKey"];
+  const ignoreKeys = ["featureKey", "traffic"];
 
   for (const [key, value] of Object.entries(evaluation)) {
     if (ignoreKeys.indexOf(key) !== -1) {
@@ -97,14 +97,8 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
   }
 
   console.log("");
-  console.log(`Evaluating feature "${options.feature}" in environment "${options.environment}..."`);
+  console.log(`Evaluating feature "${options.feature}" in environment "${options.environment}"...`);
   console.log(`Against context: ${JSON.stringify(options.context)}`);
-
-  // bucketing
-  printHeader("Bucketing");
-
-  // console.log("Bucket key:", flagEvaluation.bucketKey); // @TODO
-  console.log("Bucket value:", flagEvaluation.bucketValue);
 
   // flag
   printHeader("Is enabled?");

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -4,7 +4,29 @@ import { Evaluation, createInstance, createLogger } from "@featurevisor/sdk";
 import { Dependencies } from "../dependencies";
 import { SCHEMA_VERSION } from "../config";
 import { buildDatafile } from "../builder";
-import { prettyNumber } from "../utils";
+
+function printEvaluationDetails(evaluation: Evaluation) {
+  const ignoreKeys = ["featureKey", "traffic", "bucketValue", "bucketKey"];
+
+  for (const [key, value] of Object.entries(evaluation)) {
+    if (ignoreKeys.indexOf(key) !== -1) {
+      continue;
+    }
+
+    if (key === "variation") {
+      console.log(`-`, `${key}:`, value?.key);
+      continue;
+    }
+
+    console.log(`-`, `${key}:`, value);
+  }
+}
+
+function printHeader(message: string) {
+  console.log("\n\n###############");
+  console.log(`# ${message}`);
+  console.log("###############\n");
+}
 
 export interface EvaluateOptions {
   environment: string;
@@ -78,33 +100,29 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
   console.log(`Evaluating feature "${options.feature}" in environment "${options.environment}..."`);
   console.log(`Against context: ${JSON.stringify(options.context)}`);
 
+  // bucketing
+  printHeader("Bucketing");
+
+  // console.log("Bucket key:", flagEvaluation.bucketKey); // @TODO
+  console.log("Bucket value:", flagEvaluation.bucketValue);
+
   // flag
-  console.log("\n###");
-  console.log("# Is enabled?");
-  console.log("#\n");
+  printHeader("Is enabled?");
 
   console.log("Value:", flagEvaluation.enabled);
-  console.log("\nDetails:");
+  console.log("\nDetails:\n");
 
-  for (const [key, value] of Object.entries(flagEvaluation)) {
-    if (key === "traffic") {
-      continue;
-    }
+  printEvaluationDetails(flagEvaluation);
 
-    console.log(`-`, `${key}:`, value);
+  // variation
+  printHeader("Variation");
+
+  if (feature?.variations) {
+    console.log("Value:", variationEvaluation.enabled);
+    console.log("\nDetails:\n");
+
+    printEvaluationDetails(variationEvaluation);
+  } else {
+    console.log("No variations available.");
   }
-
-  // const variation = f.getVariation(options.feature, options.context as Context);
-  // console.log("Variation:", variation);
-
-  // const feature = f.getFeature(options.feature);
-
-  // if (feature?.variablesSchema) {
-  //   console.log("Variables:");
-
-  //   feature.variablesSchema.forEach((v) => {
-  //     const variableValue = f.getVariable(options.feature, v.key, options.context as Context);
-  //     console.log(`  - "${v.key}": ${variableValue}`);
-  //   });
-  // }
 }

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -118,7 +118,7 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
   printHeader("Variation");
 
   if (feature?.variations) {
-    console.log("Value:", variationEvaluation.variation?.value);
+    console.log("Value:", JSON.stringify(variationEvaluation.variation?.value));
     console.log("\nDetails:\n");
 
     printEvaluationDetails(variationEvaluation);
@@ -131,7 +131,12 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
     for (const [key, value] of Object.entries(variableEvaluations)) {
       printHeader(`Variable: ${key}`);
 
-      console.log("Value:", value.variableValue);
+      console.log(
+        "Value:",
+        typeof value.variableValue !== "undefined"
+          ? JSON.stringify(value.variableValue)
+          : value.variableValue,
+      );
       console.log("\nDetails:\n");
 
       printEvaluationDetails(value);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,4 @@ export * from "./find-usage";
 export * from "./dependencies";
 export * from "./datasource";
 export * from "./benchmark";
+export * from "./evaluate";

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./extractKeys";
 export * from "./git";
+export * from "./pretty";

--- a/packages/core/src/utils/pretty.ts
+++ b/packages/core/src/utils/pretty.ts
@@ -1,0 +1,3 @@
+export function prettyNumber(n: number) {
+  return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -85,25 +85,47 @@ export function getMatchedTrafficAndAllocation(
   };
 }
 
+export interface ForceResult {
+  force?: Force;
+  forceIndex?: number;
+}
+
 export function findForceFromFeature(
   feature: Feature,
   context: Context,
   datafileReader: DatafileReader,
   logger: Logger,
-): Force | undefined {
+): ForceResult {
+  const result: ForceResult = {
+    force: undefined,
+    forceIndex: undefined,
+  };
+
   if (!feature.force) {
-    return undefined;
+    return result;
   }
 
-  return feature.force.find((f: Force) => {
-    if (f.conditions) {
-      return allConditionsAreMatched(f.conditions, context, logger);
+  for (let i = 0; i < feature.force.length; i++) {
+    const currentForce = feature.force[i];
+
+    if (
+      currentForce.conditions &&
+      allConditionsAreMatched(currentForce.conditions, context, logger)
+    ) {
+      result.force = currentForce;
+      result.forceIndex = i;
+      break;
     }
 
-    if (f.segments) {
-      return allGroupSegmentsAreMatched(f.segments, context, datafileReader, logger);
+    if (
+      currentForce.segments &&
+      allGroupSegmentsAreMatched(currentForce.segments, context, datafileReader, logger)
+    ) {
+      result.force = currentForce;
+      result.forceIndex = i;
+      break;
     }
+  }
 
-    return false;
-  });
+  return result;
 }

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -17,6 +17,7 @@ import {
   RuleKey,
   VariableKey,
   VariableSchema,
+  Force,
 } from "@featurevisor/types";
 
 import { createLogger, Logger, LogLevel } from "./logger";
@@ -110,6 +111,8 @@ export interface Evaluation {
   error?: Error;
   enabled?: boolean;
   traffic?: Traffic;
+  forceIndex?: number;
+  force?: Force;
   sticky?: OverrideFeature;
   initial?: OverrideFeature;
 
@@ -533,12 +536,19 @@ export class FeaturevisorInstance {
       const finalContext = this.interceptContext ? this.interceptContext(context) : context;
 
       // forced
-      const force = findForceFromFeature(feature, context, this.datafileReader, this.logger);
+      const { force, forceIndex } = findForceFromFeature(
+        feature,
+        context,
+        this.datafileReader,
+        this.logger,
+      );
 
       if (force && typeof force.enabled !== "undefined") {
         evaluation = {
           featureKey: feature.key,
           reason: EvaluationReason.FORCED,
+          forceIndex,
+          force,
           enabled: force.enabled,
         };
 
@@ -796,7 +806,12 @@ export class FeaturevisorInstance {
       const finalContext = this.interceptContext ? this.interceptContext(context) : context;
 
       // forced
-      const force = findForceFromFeature(feature, context, this.datafileReader, this.logger);
+      const { force, forceIndex } = findForceFromFeature(
+        feature,
+        context,
+        this.datafileReader,
+        this.logger,
+      );
 
       if (force && force.variation) {
         const variation = feature.variations.find((v) => v.value === force.variation);
@@ -805,6 +820,8 @@ export class FeaturevisorInstance {
           evaluation = {
             featureKey: feature.key,
             reason: EvaluationReason.FORCED,
+            forceIndex,
+            force,
             variation,
           };
 
@@ -1066,12 +1083,19 @@ export class FeaturevisorInstance {
       const finalContext = this.interceptContext ? this.interceptContext(context) : context;
 
       // forced
-      const force = findForceFromFeature(feature, context, this.datafileReader, this.logger);
+      const { force, forceIndex } = findForceFromFeature(
+        feature,
+        context,
+        this.datafileReader,
+        this.logger,
+      );
 
       if (force && force.variables && typeof force.variables[variableKey] !== "undefined") {
         evaluation = {
           featureKey: feature.key,
           reason: EvaluationReason.FORCED,
+          forceIndex,
+          force,
           variableKey,
           variableSchema,
           variableValue: force.variables[variableKey],


### PR DESCRIPTION
## What's done

For debugging purposes, a new command has been introduced:

```
$ npx featurevisor evaluate \
  --environment=production \
  --feature=my_feature \
  --context='{"userId": "123", "country": "nl"}'
```

To print as JSON:

```
$ npx featurevisor evaluate \
  --environment=production \
  --feature=my_feature \
  --context='{"userId": "123", "country": "nl"}' \
  --print \
  --pretty
```