### PR TITLE
feat: assess traffic distribution via CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -156,7 +156,7 @@ The `--n` option is used to specify the number of iterations to run the benchmar
 
 ### Feature
 
-To benchmark evaluating a feature itself if it is enabled or disabled via SDK's `.isEnabled()` method:
+To benchmark evaluating a feature itself if it is enabled or disabled via SDK's `.isEnabled()` method against provided [context](/docs/sdks/javascript/#context):
 
 ```
 $ npx featurevisor benchmark \
@@ -208,7 +208,7 @@ $ npx featurevisor config --print --pretty
 
 ## Evaluate
 
-To learn why certain values (like feature and its variation or variables) are evaluated as they are:
+To learn why certain values (like feature and its variation or variables) are evaluated as they are against provided [context](/docs/sdks/javascript/#context):
 
 ```
 $ npx featurevisor evaluate \
@@ -233,3 +233,31 @@ $ npx featurevisor evaluate \
 ```
 
 The `--pretty` flag is optional.
+
+## Assess distribution
+
+To check if the gradual rollout of a feature and the weight distribution of its variations (if any exists) are going to work as expected in a real world application with real traffic against provided [context](/docs/sdks/javascript/#context), we can imitate that by running:
+
+```
+$ npx featurevisor assess-distribution \
+  --environment=production \
+  --feature=my_feature \
+  --context='{"country": "nl"}' \
+  --populateUuid=userId \
+  --n=1000
+```
+
+The `--n` option controls the number of iterations to run, and the `--populateUuid` option is used to simulate different users in each iteration in this particular case.
+
+Further details about all the options:
+
+- `--environment`: the environment name
+- `--feature`: the feature key
+- `--context`: the common [context](/docs/sdks/javascript/#context) object in stringified form
+- `--populateUuid`: attribute key that should be populated with a new UUID, and merged with provided context.
+  - You can pass multiple attributes in your command: `--populateUuid=userId --populateUuid=deviceId`
+- `--n`: the number of iterations to run the assessment for
+  - The higher the number, the more accurate the distribution will be
+- `--verbose`: print the merged context for better debugging
+
+Everything is happening locally in memory without modifying any content anywhere. This command exists only to add to our confidence if questions arise about how effective traffic distribution in Featurevisor is.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import {
   benchmarkFeature,
   showProjectConfig,
   evaluateFeature,
+  assessDistribution,
 } from "@featurevisor/core";
 
 process.on("unhandledRejection", (reason) => {
@@ -365,6 +366,47 @@ async function main() {
     .example(
       "$0 evaluate --environment=production --feature=my_feature --context='{}'",
       "evaluate a feature against provided context",
+    )
+
+    /**
+     * Assess distribution
+     */
+    .command({
+      command: "assess-distribution",
+      handler: async function (options) {
+        if (!options.environment) {
+          console.error("Please specify an environment with --environment flag.");
+          process.exit(1);
+        }
+
+        if (!options.feature) {
+          console.error("Please specify a feature with --feature flag.");
+          process.exit(1);
+        }
+
+        const deps = await getDependencies(options);
+
+        try {
+          await assessDistribution(deps, {
+            environment: options.environment,
+            feature: options.feature,
+            context: options.context ? JSON.parse(options.context) : {},
+            populateUuid: Array.isArray(options.populateUuid)
+              ? options.populateUuid
+              : [options.populateUuid as string].filter(Boolean),
+            n: parseInt(options.n, 10) || 1,
+            verbose: options.verbose,
+          });
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1);
+        }
+      },
+    })
+    .example("$0 assess-distribution", "test traffic distribution of a feature")
+    .example(
+      "$0 assess-distribution --environment=production --feature=my_feature --context='{}' --populateUuid=userId --n=100",
+      "test traffic distribution a feature against provided context",
     )
 
     /**

--- a/packages/core/src/assess-distribution/index.ts
+++ b/packages/core/src/assess-distribution/index.ts
@@ -1,0 +1,167 @@
+import { randomBytes } from "crypto";
+
+import { FeatureKey, AttributeKey, Context } from "@featurevisor/types";
+import { createInstance } from "@featurevisor/sdk";
+
+import { Dependencies } from "../dependencies";
+import { buildDatafile } from "../builder";
+import { SCHEMA_VERSION } from "../config";
+import { prettyPercentage, prettyNumber } from "../utils";
+
+const UUID_LENGTHS = [4, 2, 2, 2, 6];
+
+function generateUUID(): string {
+  return UUID_LENGTHS.map((len) => randomBytes(len).toString("hex")).join("-");
+}
+
+type EvaluationsCount = Record<string, number>;
+
+function printCounts(evaluations: EvaluationsCount, n: number, sort = true) {
+  let entries = Object.entries(evaluations);
+
+  if (sort) {
+    entries = entries.sort((a, b) => {
+      if (a[1] > b[1]) {
+        return -1;
+      }
+
+      if (a[1] < b[1]) {
+        return 1;
+      }
+
+      return 0;
+    });
+  }
+
+  const longestValueLength = Object.keys(evaluations).reduce(
+    (acc, curr) => (curr.length > acc ? curr.length : acc),
+    0,
+  );
+
+  const highestCount = Object.values(evaluations).reduce(
+    (acc, curr) => (curr > acc ? curr : acc),
+    0,
+  );
+  const prettyHighestCountLength = prettyNumber(highestCount).length;
+
+  for (const [value, count] of entries) {
+    console.log(
+      `  - ${value}:`.padEnd(longestValueLength + 5, " "),
+      `\t${prettyNumber(count).padStart(prettyHighestCountLength, " ")}`,
+      `\t${prettyPercentage(count, n).padStart(7, " ")}`,
+    );
+  }
+}
+
+function createContext(providedContext: Context, populateUuid?: AttributeKey[]): Context {
+  const context = { ...providedContext };
+
+  if (populateUuid) {
+    for (const key of populateUuid) {
+      context[key] = generateUUID();
+    }
+  }
+
+  return context;
+}
+
+export interface AssessDistributionOptions {
+  environment: string;
+  feature: FeatureKey;
+  context: Context;
+  n: number;
+
+  populateUuid?: AttributeKey[];
+  verbose?: boolean;
+}
+
+export async function assessDistribution(deps: Dependencies, options: AssessDistributionOptions) {
+  const { projectConfig, datasource } = deps;
+
+  console.log(`\nAssessing distribution for feature: "${options.feature}"...`);
+
+  /**
+   * Prepare datafile
+   */
+  const datafileBuildStart = Date.now();
+  console.log(`\n\nBuilding datafile containing all features for "${options.environment}"...`);
+  const existingState = await datasource.readState(options.environment);
+  const datafileContent = await buildDatafile(
+    projectConfig,
+    datasource,
+    {
+      schemaVersion: SCHEMA_VERSION,
+      revision: "include-all-features",
+      environment: options.environment,
+    },
+    existingState,
+  );
+  const datafileBuildDuration = Date.now() - datafileBuildStart;
+  console.log(`Datafile build duration: ${datafileBuildDuration}ms`);
+
+  /**
+   * Initialize SDK
+   */
+  const f = createInstance({
+    datafile: datafileContent,
+  });
+  console.log("\n\n...SDK initialized\n");
+
+  /**
+   * Evaluations
+   */
+  let hasVariations = false;
+  const feature = f.getFeature(options.feature);
+
+  if (feature && feature.variations) {
+    hasVariations = true;
+  }
+
+  const flagEvaluations: EvaluationsCount = {
+    enabled: 0,
+    disabled: 0,
+  };
+
+  const variationEvaluations: EvaluationsCount = {};
+
+  console.log(`\nEvaluating ${prettyNumber(options.n)} times...`);
+
+  for (let i = 0; i < options.n; i++) {
+    const context = createContext(options.context, options.populateUuid);
+    if (options.verbose) {
+      console.log(`[${i + 1}/${options.n}] Evaluating against context: ${JSON.stringify(context)}`);
+    }
+
+    // flag
+    const flagEvaluation = f.isEnabled(options.feature, context);
+
+    if (flagEvaluation) {
+      flagEvaluations.enabled++;
+    } else {
+      flagEvaluations.disabled++;
+    }
+
+    // variation
+    if (hasVariations) {
+      const variationEvaluation = f.getVariation(options.feature, context) as string;
+
+      if (!variationEvaluations[variationEvaluation]) {
+        variationEvaluations[variationEvaluation] = 0;
+      }
+
+      variationEvaluations[variationEvaluation]++;
+    }
+  }
+
+  /**
+   * Print results
+   */
+
+  console.log("\n\nFlag evaluations:\n");
+  printCounts(flagEvaluations, options.n);
+
+  if (hasVariations) {
+    console.log("\n\nVariation evaluations:\n");
+    printCounts(variationEvaluations, options.n);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,4 @@ export * from "./dependencies";
 export * from "./datasource";
 export * from "./benchmark";
 export * from "./evaluate";
+export * from "./assess-distribution";

--- a/packages/core/src/utils/pretty.ts
+++ b/packages/core/src/utils/pretty.ts
@@ -1,3 +1,12 @@
 export function prettyNumber(n: number) {
   return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
+
+export function prettyPercentage(
+  value: number,
+  total: number,
+  precision: number = 2,
+  suffix: string = "%",
+): string {
+  return `${((value / total) * 100).toFixed(precision)}${suffix}`;
+}


### PR DESCRIPTION
## What's done

A new command has been introduced in CLI.

See docs in diff for more info.

## Examples

### Feature and its variation evaluations

```
$ npx featurevisor assess-distribution \
  --environment=production \
  --feature=sidebar \
  --context='{"country": "nl"}' \
  --populateUuid=userId \
  --n=1000

Assessing distribution for feature: "sidebar"...


Building datafile containing all features for "production"...
Datafile build duration: 19ms


...SDK initialized


Evaluating 1,000 times...


Flag evaluations:

  - enabled:  	1,000 	100.00%
  - disabled: 	    0 	  0.00%


Variation evaluations:

  - treatment: 	896 	 89.60%
  - control:   	104 	 10.40%
```

### Verbosity

Adding `--verbose` helps see the final merged `context` that is passed to SDK for each evaluation:

```
$ npx featurevisor assess-distribution \
  --environment=production \
  --feature=sidebar \
  --context='{"country": "nl"}' \
  --populateUuid=userId \
  --n=5 \
  --verbose

Assessing distribution for feature: "sidebar"...


Building datafile containing all features for "production"...
Datafile build duration: 16ms


...SDK initialized


Evaluating 5 times...
[1/5] Evaluating against context: {"country":"nl","userId":"116bc876-17a8-3a7d-3ab8-9d100a7f0867"}
[2/5] Evaluating against context: {"country":"nl","userId":"210e5cf3-6394-0483-5746-8040cd4b3089"}
[3/5] Evaluating against context: {"country":"nl","userId":"90c8d74a-f824-2a1a-10e6-f6c03595a73e"}
[4/5] Evaluating against context: {"country":"nl","userId":"ab0ab049-1940-c9e6-6774-9e7d2227da91"}
[5/5] Evaluating against context: {"country":"nl","userId":"03b17d06-ae08-1f2e-20a6-4d7afc127c1a"}


Flag evaluations:

  - enabled:  	5 	100.00%
  - disabled: 	0 	  0.00%


Variation evaluations:

  - treatment: 	4 	 80.00%
  - control:   	1 	 20.00%
```

You can see how `userId` was populated with a different UUID as a value for each iteration.

This happens because we passed `--populateUuid=userId`, which took care of populating it in context helping simulate our feature being evaluated by different users.