### PR TITLE
fix: search features by any case in generated site

### DIFF
--- a/packages/site/src/utils/index.ts
+++ b/packages/site/src/utils/index.ts
@@ -129,7 +129,10 @@ export function getFeaturesByQuery(query: Query, data: SearchIndex) {
     .filter((feature) => {
       let matched = true;
 
-      if (query.keyword.length > 0 && feature.key.indexOf(query.keyword.toLowerCase()) === -1) {
+      if (
+        query.keyword.length > 0 &&
+        feature.key.toLowerCase().indexOf(query.keyword.toLowerCase()) === -1
+      ) {
         matched = false;
       }
 


### PR DESCRIPTION
## Background

Featurevisor supports generating a static site serving as a read-only dashboard: https://featurevisor.com/docs/site/

## Issue

When searching for features, it wasn't honouring upper cased characters when input in the search bar.

## What's done

When applying the filtering, it will now lowercase everything so that search results are returned as intended.