### PR TITLE
feat: find duplicate segments with authors info

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,6 +120,12 @@ We can find these duplicates early on by running:
 $ npx featurevisor find-duplicate-segments
 ```
 
+If we want to know the names of authors who worked on the duplicate segments, we can pass `--authors`:
+
+```
+$ npx featurevisor find-duplicate-segments --authors
+```
+
 ## Find usage
 
 Learn where/if certain segments and attributes are used in.

--- a/packages/core/src/find-duplicate-segments/index.ts
+++ b/packages/core/src/find-duplicate-segments/index.ts
@@ -1,19 +1,28 @@
-import { findDuplicateSegments } from "./findDuplicateSegments";
+import { findDuplicateSegments, DuplicateSegmentsOptions } from "./findDuplicateSegments";
 import { Dependencies } from "../dependencies";
 
-export async function findDuplicateSegmentsInProject(deps: Dependencies) {
-  const { datasource } = deps;
+export async function findDuplicateSegmentsInProject(
+  deps: Dependencies,
+  options: DuplicateSegmentsOptions = {},
+) {
+  const duplicates = await findDuplicateSegments(deps, options);
 
-  const duplicates = await findDuplicateSegments(datasource);
+  console.log("");
 
   if (duplicates.length === 0) {
     console.log("No duplicate segments found");
     return;
   }
 
-  console.log(`Found ${duplicates.length} duplicates:\n`);
+  console.log(`Found ${duplicates.length} duplicate(s):\n`);
 
-  duplicates.forEach((segmentKeys) => {
-    console.log(`  - ${segmentKeys.join(", ")}`);
+  duplicates.forEach((entry) => {
+    if (options.authors) {
+      console.log(`  - Segments: ${entry.segments.join(", ")}`);
+      console.log(`    Authors:  ${entry.authors && entry.authors.join(", ")}`);
+      console.log("");
+    } else {
+      console.log(`  - ${entry.segments.join(", ")}`);
+    }
   });
 }


### PR DESCRIPTION
## Background

We have a command for finding segments with same conditions as other segments:

```
$ npx featurevisor find-duplicate-segments
```

More info: https://featurevisor.com/docs/cli/#find-duplicate-segments

## What's done

A new `--authors` option has now been introduced, to also show who are the people who modified the affected segments.

The information is extracted from Git repository's history:

```
$ npx featurevisor find-duplicate-segments --authors
```