### PR TITLE
feat: allow evaluating in CLI with more verbosity

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -240,6 +240,16 @@ $ npx featurevisor evaluate \
 
 The `--pretty` flag is optional.
 
+To print further logs in a more verbose way, you can pass `--verbose`:
+
+```
+$ npx featurevisor evaluate \
+  --environment=production \
+  --feature=my_feature \
+  --context='{"userId": "123", "country": "nl"}' \
+  --verbose
+```
+
 ## Assess distribution
 
 To check if the gradual rollout of a feature and the weight distribution of its variations (if any exists) are going to work as expected in a real world application with real traffic against provided [context](/docs/sdks/javascript/#context), we can imitate that by running:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -360,6 +360,7 @@ async function main() {
             context: options.context ? JSON.parse(options.context) : {},
             print: options.print,
             pretty: options.pretty,
+            verbose: options.verbose,
           });
         } catch (e) {
           console.error(e.message);

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -87,6 +87,7 @@ export type DatafileFetchHandler = (datafileUrl: string) => Promise<DatafileCont
 export enum EvaluationReason {
   NOT_FOUND = "not_found",
   NO_VARIATIONS = "no_variations",
+  NO_MATCH = "no_match",
   DISABLED = "disabled",
   REQUIRED = "required",
   OUT_OF_RANGE = "out_of_range",
@@ -688,7 +689,7 @@ export class FeaturevisorInstance {
       // nothing matched
       evaluation = {
         featureKey: feature.key,
-        reason: EvaluationReason.ERROR, // @TODO: any better reason?
+        reason: EvaluationReason.NO_MATCH,
         bucketKey,
         bucketValue,
         enabled: false,
@@ -894,7 +895,7 @@ export class FeaturevisorInstance {
       // nothing matched
       evaluation = {
         featureKey: feature.key,
-        reason: EvaluationReason.ERROR, // @TODO: any better reason?
+        reason: EvaluationReason.NO_MATCH,
         bucketKey,
         bucketValue,
       };


### PR DESCRIPTION
## What's done

### SDK evaluation reason

SDK evaluation reason expanded with a new reason `no_match`.

This reason is used when evaluation logic cannot not match with any specific rule against given context.

### Verbose evaluation

We allow evaluating features in CLI already: https://featurevisor.com/docs/cli/#evaluate

A new `--verbose` option has been introduced that will print SDK logs for debugging even better, if needs arise.