### PR TITLE
feat: make test runner fast by default

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -214,15 +214,7 @@ $ npx featurevisor test --onlyFailures
 
 ### `fast`
 
-By default, Featurevisor's test runner would generate a datafile for your feature against the desired environment for each assertion.
-
-If you have a lot of tests, this can be time-consuming. You can use the `--fast` option to generate datafiles for each environment early packing all the features in the project together, and then run the assertions:
-
-```
-$ npx featurevisor test --fast
-```
-
-**Note**: This approach is memory intensive and therefore not the default behaviour yet.
+This option has been deprecated, because test runner is now fast by default.
 
 ## NPM scripts
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -155,7 +155,6 @@ async function main() {
           assertionPattern: options.assertionPattern,
           verbose: options.verbose || false,
           showDatafile: options.showDatafile || false,
-          fast: options.fast || false,
           onlyFailures: options.onlyFailures || false,
         };
 

--- a/packages/core/src/tester/testFeature.ts
+++ b/packages/core/src/tester/testFeature.ts
@@ -9,7 +9,6 @@ import { createInstance, MAX_BUCKETED_NUMBER } from "@featurevisor/sdk";
 
 import { Datasource } from "../datasource";
 import { ProjectConfig } from "../config";
-import { getCustomDatafile } from "../builder";
 
 import { checkIfArraysAreEqual } from "./checkIfArraysAreEqual";
 import { checkIfObjectsAreEqual } from "./checkIfObjectsAreEqual";
@@ -55,15 +54,7 @@ export async function testFeature(
         continue;
       }
 
-      const datafileContent =
-        typeof datafileContentByEnvironment[assertion.environment] !== "undefined"
-          ? datafileContentByEnvironment[assertion.environment]
-          : await getCustomDatafile({
-              featureKey: test.feature,
-              environment: assertion.environment,
-              projectConfig,
-              datasource,
-            });
+      const datafileContent = datafileContentByEnvironment[assertion.environment];
 
       if (options.showDatafile) {
         console.log("");

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -18,7 +18,6 @@ export interface TestProjectOptions {
   verbose?: boolean;
   showDatafile?: boolean;
   onlyFailures?: boolean;
-  fast?: boolean;
 }
 
 export interface TestPatterns {
@@ -150,22 +149,21 @@ export async function testProject(
   let failedAssertionsCount = 0;
 
   const datafileContentByEnvironment: DatafileContentByEnvironment = {};
-  if (options.fast) {
-    for (const environment of projectConfig.environments) {
-      const existingState = await datasource.readState(environment);
-      const datafileContent = await buildDatafile(
-        projectConfig,
-        datasource,
-        {
-          schemaVersion: SCHEMA_VERSION,
-          revision: "include-all-features",
-          environment: environment,
-        },
-        existingState,
-      );
 
-      datafileContentByEnvironment[environment] = datafileContent;
-    }
+  for (const environment of projectConfig.environments) {
+    const existingState = await datasource.readState(environment);
+    const datafileContent = await buildDatafile(
+      projectConfig,
+      datasource,
+      {
+        schemaVersion: SCHEMA_VERSION,
+        revision: "include-all-features",
+        environment: environment,
+      },
+      existingState,
+    );
+
+    datafileContentByEnvironment[environment] = datafileContent;
   }
 
   for (const testFile of testFiles) {


### PR DESCRIPTION
## Background

A new `--fast` option was introduced in `$ npx featurevisor test --fast` via https://github.com/featurevisor/featurevisor/pull/267

## What's done

There's very good feedback about this `--fast` mode, and now it has been made the default and only way of running our tests.

Therefore the `--fast` option has been deprecated.