### PR TITLE
feat: enforce catch-all rule in features with configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,3 +86,7 @@ To disable this stringification, you can set it to `false`.
 ### `parser`
 
 By default, Featurevisor expects YAML for all definitions. You can change this to JSON by setting `parser: "json"`.
+
+### `enforceCatchAllRule`
+
+When set to `true`, linting will make sure all features have a catch-all rule with `segment: "*"` as the last rule in all environments.

--- a/examples/example-1/features/footer.yml
+++ b/examples/example-1/features/footer.yml
@@ -12,6 +12,10 @@ environments:
           - not:
               - version_5.5
         percentage: 100
+
+      - key: "2"
+        segments: "*"
+        percentage: 0
   production:
     rules:
       - key: "1"

--- a/examples/example-1/features/redesign.yml
+++ b/examples/example-1/features/redesign.yml
@@ -16,3 +16,7 @@ environments:
       - key: "1"
         segments: netherlands
         percentage: 100
+
+      - key: "2"
+        segments: "*"
+        percentage: 0

--- a/examples/example-1/featurevisor.config.js
+++ b/examples/example-1/featurevisor.config.js
@@ -4,4 +4,5 @@ module.exports = {
   tags: ["all", "checkout"],
   prettyState: true,
   prettyDatafile: true,
+  enforceCatchAllRule: true,
 };

--- a/packages/core/src/config/projectConfig.ts
+++ b/packages/core/src/config/projectConfig.ts
@@ -44,6 +44,7 @@ export interface ProjectConfig {
   prettyDatafile: boolean;
   stringify: boolean;
   siteExportDirectoryPath: string;
+  enforceCatchAllRule?: boolean;
   adapter: any; // @TODO: type this properly later
 }
 
@@ -70,6 +71,8 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
     stateDirectoryPath: path.join(rootDirectoryPath, STATE_DIRECTORY_NAME),
     outputDirectoryPath: path.join(rootDirectoryPath, OUTPUT_DIRECTORY_NAME),
     siteExportDirectoryPath: path.join(rootDirectoryPath, SITE_EXPORT_DIRECTORY_NAME),
+
+    enforceCatchAllRule: false,
   };
 
   const configModulePath = path.join(rootDirectoryPath, CONFIG_MODULE_NAME);

--- a/packages/core/src/linter/featureSchema.ts
+++ b/packages/core/src/linter/featureSchema.ts
@@ -87,6 +87,16 @@ export function getFeatureZodSchema(
             })
             .strict(),
         )
+
+        // must have at least one rule
+        .refine(
+          (value) => value.length > 0,
+          () => ({
+            message: "Must have at least one rule",
+          }),
+        )
+
+        // duplicate rules
         .refine(
           (value) => {
             const keys = value.map((v) => v.key);
@@ -94,6 +104,21 @@ export function getFeatureZodSchema(
           },
           (value) => ({
             message: "Duplicate rule keys found: " + value.map((v) => v.key).join(", "),
+          }),
+        )
+
+        // enforce catch-all rule
+        .refine(
+          (value) => {
+            if (!projectConfig.enforceCatchAllRule) {
+              return true;
+            }
+
+            const hasCatchAllAsLastRule = value[value.length - 1].segments === "*";
+            return hasCatchAllAsLastRule;
+          },
+          () => ({
+            message: `Missing catch-all rule with \`segments: "*"\` at the end`,
           }),
         ),
       force: z


### PR DESCRIPTION
## Background

Featurevisor lets you define rules in features against individual environments: https://featurevisor.com/docs/features/#rules

Currently, there's no strict requirement to have a catch-all rule (matching everyone) as the last rule inside individual environments:

```yml
# features/my_feature.yml

# ...

environments:
  production:
    - key: nl
      segments: netherlands
      percentage: 100

    # this is optional in Featurevisor
    - key: everyone
      segments: "*" # catch-all
      percentage: 0
```

## What's done

A new project configuration has been introduced:

```js
// featurevisor.config.js
module.exports = {
  // ...

  enforceCatchAllRule: true, // false by default
};
```

If set to `true`, linting will fail if there are any features found that do not have a catch-all rule in any environment:

```
$ npx featurevisor lint
```