### PR TITLE
tests for checking if datafile fetch is graceful

### DIFF
--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -1394,4 +1394,15 @@ describe("sdk: instance", function () {
     expect(sdk.isEnabled("test", { userId: "123", country: "nl" })).toEqual(true);
     expect(sdk.isEnabled("test", { userId: "123", country: "us", device: "iphone" })).toEqual(true);
   });
+
+  it.only("should handle datafile fetch error gracefully", function (done) {
+    const sdk = createInstance({
+      datafileUrl: "http://localhost:9090/datafile-tag-non-existing.json",
+    });
+
+    setTimeout(function () {
+      expect(sdk.isReady()).toEqual(false);
+      done();
+    }, 100);
+  });
 });


### PR DESCRIPTION
## What is the PR about?

Trying to reproduce #306 

cc @meirroth 

## Intention

- Verify if datafile fetch is graceful (meaning, we do not want to crash the application if fetch is unsuccessful)
- We still want to emit an error log out, which will be handled via logger instance

## Result

- This PR proves that datafile fetch by SDK is graceful already (otherwise the tests would have crashed)