### PR TITLE
feat: show variables count from CLI

### DIFF
--- a/packages/core/src/info/index.ts
+++ b/packages/core/src/info/index.ts
@@ -21,7 +21,7 @@ export async function showProjectInfo(deps: Dependencies) {
     const feature = await datasource.readFeature(featureKey);
 
     if (feature.variablesSchema) {
-      variablesCount += Object.keys(feature.variablesSchema).length;
+      variablesCount += feature.variablesSchema.length;
     }
   }
 

--- a/packages/core/src/info/index.ts
+++ b/packages/core/src/info/index.ts
@@ -16,9 +16,19 @@ export async function showProjectInfo(deps: Dependencies) {
   const features = await datasource.listFeatures();
   const groups = await datasource.listGroups();
 
+  let variablesCount = 0;
+  for (const featureKey of features) {
+    const feature = await datasource.readFeature(featureKey);
+
+    if (feature.variablesSchema) {
+      variablesCount += Object.keys(feature.variablesSchema).length;
+    }
+  }
+
   console.log("  - Total attributes: ", attributes.length);
   console.log("  - Total segments:   ", segments.length);
   console.log("  - Total features:   ", features.length);
+  console.log("  - Total variables:  ", variablesCount);
   console.log("  - Total groups:     ", groups.length);
 
   console.log("");


### PR DESCRIPTION
## What's done

`$ npx featurevisor info` will now also show total variables count.

Example:

```
$ npx featurevisor info

Project info:

  - Revision:          28

  - Total attributes:  7
  - Total segments:    11
  - Total features:    14
  - Total variables:   13
  - Total groups:      1

  - Total test specs:  14
  - Total assertions:  72
```