### PR TITLE
feat: allow showing authors when finding unused entities

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,6 +130,8 @@ $ npx featurevisor find-duplicate-segments --authors
 
 Learn where/if certain segments and attributes are used in.
 
+For each of the `find-usage` commands below, you can optionally pass `--authors` to find who worked on the affected entities.
+
 ### Segment usage
 
 ```

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -257,6 +257,8 @@ async function main() {
 
             unusedSegments: options.unusedSegments,
             unusedAttributes: options.unusedAttributes,
+
+            authors: options.authors,
           });
         } catch (e) {
           console.error(e.message);

--- a/packages/core/src/find-usage/index.ts
+++ b/packages/core/src/find-usage/index.ts
@@ -243,9 +243,13 @@ export interface FindUsageOptions {
 
   unusedSegments?: boolean;
   unusedAttributes?: boolean;
+
+  authors?: boolean;
 }
 
 export async function findUsageInProject(deps: Dependencies, options: FindUsageOptions) {
+  const { datasource } = deps;
+
   console.log("");
 
   // segment
@@ -257,9 +261,16 @@ export async function findUsageInProject(deps: Dependencies, options: FindUsageO
     } else {
       console.log(`Segment "${options.segment}" is used in the following features:\n`);
 
-      usedInFeatures.forEach((featureKey) => {
-        console.log(`  - ${featureKey}`);
-      });
+      for (const featureKey of Array.from(usedInFeatures)) {
+        if (options.authors) {
+          const entries = await datasource.listHistoryEntries("feature", featureKey);
+          const authors = Array.from(new Set(entries.map((entry) => entry.author)));
+
+          console.log(`  - ${featureKey} (Authors: ${authors.join(", ")})`);
+        } else {
+          console.log(`  - ${featureKey}`);
+        }
+      }
     }
 
     return;
@@ -278,9 +289,16 @@ export async function findUsageInProject(deps: Dependencies, options: FindUsageO
     if (usedIn.features.size > 0) {
       console.log(`Attribute "${options.attribute}" is used in the following features:\n`);
 
-      usedIn.features.forEach((featureKey) => {
-        console.log(`  - ${featureKey}`);
-      });
+      for (const featureKey of Array.from(usedIn.features)) {
+        if (options.authors) {
+          const entries = await datasource.listHistoryEntries("feature", featureKey);
+          const authors = Array.from(new Set(entries.map((entry) => entry.author)));
+
+          console.log(`  - ${featureKey} (Authors: ${authors.join(", ")})`);
+        } else {
+          console.log(`  - ${featureKey}`);
+        }
+      }
 
       console.log("");
     }
@@ -288,9 +306,16 @@ export async function findUsageInProject(deps: Dependencies, options: FindUsageO
     if (usedIn.segments.size > 0) {
       console.log(`Attribute "${options.attribute}" is used in the following segments:\n`);
 
-      usedIn.segments.forEach((segmentKey) => {
-        console.log(`  - ${segmentKey}`);
-      });
+      for (const segmentKey of Array.from(usedIn.segments)) {
+        if (options.authors) {
+          const entries = await datasource.listHistoryEntries("segment", segmentKey);
+          const authors = Array.from(new Set(entries.map((entry) => entry.author)));
+
+          console.log(`  - ${segmentKey} (Authors: ${authors.join(", ")})`);
+        } else {
+          console.log(`  - ${segmentKey}`);
+        }
+      }
     }
 
     return;
@@ -305,9 +330,16 @@ export async function findUsageInProject(deps: Dependencies, options: FindUsageO
     } else {
       console.log("Unused segments:\n");
 
-      unusedSegments.forEach((segmentKey) => {
-        console.log(`  - ${segmentKey}`);
-      });
+      for (const segmentKey of Array.from(unusedSegments)) {
+        if (options.authors) {
+          const entries = await datasource.listHistoryEntries("segment", segmentKey);
+          const authors = Array.from(new Set(entries.map((entry) => entry.author)));
+
+          console.log(`  - ${segmentKey} (Authors: ${authors.join(", ")})`);
+        } else {
+          console.log(`  - ${segmentKey}`);
+        }
+      }
     }
 
     return;
@@ -322,9 +354,16 @@ export async function findUsageInProject(deps: Dependencies, options: FindUsageO
     } else {
       console.log("Unused attributes:\n");
 
-      unusedAttributes.forEach((attributeKey) => {
-        console.log(`  - ${attributeKey}`);
-      });
+      for (const attributeKey of Array.from(unusedAttributes)) {
+        if (options.authors) {
+          const entries = await datasource.listHistoryEntries("attribute", attributeKey);
+          const authors = Array.from(new Set(entries.map((entry) => entry.author)));
+
+          console.log(`  - ${attributeKey} (Authors: ${authors.join(", ")})`);
+        } else {
+          console.log(`  - ${attributeKey}`);
+        }
+      }
     }
 
     return;


### PR DESCRIPTION
## What's done

We already had these commands:

```
$ npx featurevisor find-usage --segment=my_segment
$ npx featurevisor find-usage --attribute=my_attribute
$ npx featurevisor find-usage --unusedSegments
$ npx featurevisor find-usage --unusedAttributes
```

Now, each of them can optionally receive `--authors` to show who worked on the affected entities:

```
$ npx featurevisor find-usage --segment=my_segment --authors
$ npx featurevisor find-usage --attribute=my_attribute --authors
$ npx featurevisor find-usage --unusedSegments --authors
$ npx featurevisor find-usage --unusedAttributes --authors
```

Docs: https://featurevisor.com/docs/cli/#find-usage