### PR TITLE
feat: allow building datafiles without making changes to state files

### DIFF
--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -44,12 +44,18 @@ Next to datafiles, the build process will also generate some additional JSON fil
 
 ## Revision
 
-By default, Featurevisor will use the `version` as exists in `package.json` of the project as the `revision` value in generated datafiles.
+By default, Featurevisor will increment the revision number as found in `.featurevisor/REVISION` file (learn more in [state files](/docs/state-files)).
 
-You can optionally customize the `revision` value in datafiles by passing a `--revision` flag when building:
+You can optionally customize the `revision` value when building datafiles by passing a `--revision` flag:
 
 ```
 $ npx featurevisor build --revision 1.2.3
+```
+
+If you wish to build datafiles without making any changes to [state files](/docs/state-files), you can pass the `--no-state-files` flag:
+
+```
+$ npx featurevisor build --no-state-files
 ```
 
 ## Printing

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -12,6 +12,7 @@ export interface BuildCLIOptions {
   feature?: string;
   print?: boolean;
   pretty?: boolean;
+  stateFiles?: boolean; // --no-state-files in CLI
 }
 
 export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptions = {}) {
@@ -84,11 +85,13 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
       });
     }
 
-    // write state for environment
-    await datasource.writeState(environment, existingState);
+    if (typeof cliOptions.stateFiles === "undefined" || cliOptions.stateFiles) {
+      // write state for environment
+      await datasource.writeState(environment, existingState);
 
-    // write revision
-    await datasource.writeRevision(nextRevision);
+      // write revision
+      await datasource.writeRevision(nextRevision);
+    }
   }
 
   console.log("\nLatest revision:", nextRevision);


### PR DESCRIPTION
## What's done

Datafiles can now optionally be built without making any changes to state files (as found in `.featurevisor` directory).

```
$ npx featurevisor build --no-state-files
```

This is handy for local debugging and testing.