### PR TITLE
feat: allow null/undefined variable values

### DIFF
--- a/examples/example-1/features/showPopup.yml
+++ b/examples/example-1/features/showPopup.yml
@@ -4,6 +4,11 @@ tags:
 
 bucketBy: userId
 
+variablesSchema:
+  - key: nullableField
+    type: string
+    defaultValue: null
+
 environments:
   staging:
     force:
@@ -15,6 +20,8 @@ environments:
             operator: equals
             value: user-3
         enabled: true
+        variables:
+          nullableField: "test value"
     rules:
       - key: "1"
         segments: "*"

--- a/examples/example-1/tests/showPopup.spec.yml
+++ b/examples/example-1/tests/showPopup.spec.yml
@@ -11,15 +11,25 @@ assertions:
     context:
       userId: "user-2"
     expectedToBeEnabled: true
+    expectedVariables:
+      nullableField: null
 
   - at: 40
     environment: staging
     context:
       userId: "user-3"
     expectedToBeEnabled: true
+    expectedVariables:
+      nullableField: test value
 
   - at: 40
     environment: staging
     context:
       userId: "user-6"
     expectedToBeEnabled: false
+
+  - at: 40
+    environment: staging
+    context:
+      userId: "user-3"
+    expectedToBeEnabled: true

--- a/examples/example-1/tests/showPopup.spec.yml
+++ b/examples/example-1/tests/showPopup.spec.yml
@@ -27,9 +27,3 @@ assertions:
     context:
       userId: "user-6"
     expectedToBeEnabled: false
-
-  - at: 40
-    environment: staging
-    context:
-      userId: "user-3"
-    expectedToBeEnabled: true

--- a/packages/core/src/linter/featureSchema.ts
+++ b/packages/core/src/linter/featureSchema.ts
@@ -41,6 +41,10 @@ function superRefineVariableValue(variableSchema, variableValue, path, ctx) {
     return;
   }
 
+  if (variableValue === null || typeof variableValue === "undefined") {
+    return;
+  }
+
   // string
   if (variableSchema.type === "string") {
     if (typeof variableValue !== "string") {
@@ -143,6 +147,8 @@ export function getFeatureZodSchema(
         message: "object is not flat",
       },
     ),
+    z.null(),
+    z.undefined(),
   ]);
 
   const plainGroupSegment = z.string().refine(


### PR DESCRIPTION
## What's done

This PR allows variable values to be set as `null` and `undefined`

## `null` vs `undefined`

JavaScript has `null` for empty values, and also `undefined` which is for variables/properties that do not exist.

Other programming languages do not have `undefined` like JavaScript, and have values like `null` or `nil` explicitly.

Currently, Featurevisor's JavaScript SDK's `.getVariable()` has a return type of either a variable type's value (like `string`, `boolean`, etc) or `undefined`.

`undefined` can be returned from `.getVariable()` if the variable does not exist, or the feature itself does not exist in datafile.

## Paths forward

- **Option A**: We allow all variables to be nullable (like done in this PR)
- **Option B**: We allow variables to be nullable only intentionally, by introducing a new `nullable: true` in individual variable's schema. Then you are allowed to use `null` as values for that specific variable.
- **Option C**: We do not allow null/undefined values to ever be set intentionally for variables (like it exists in latest published version of Featurevisor)