### PR TITLE
fix: ESM bundle for SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ lint:
 # Misc.
 #
 print-bundle-size:
-	@gzip -c packages/sdk/dist/index.esm.js > packages/sdk/dist/index.esm.js.gz
+	@gzip -c packages/sdk/dist/index.mjs > packages/sdk/dist/index.mjs.gz
 	@echo 'SDK package size:'
-	@ls -alh packages/sdk/dist | grep index.esm.js | awk '{print $$9 "\t" $$5}'
+	@ls -alh packages/sdk/dist | grep index.mjs | awk '{print $$9 "\t" $$5}'
 
 	@echo ''
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ lint:
 # Misc.
 #
 print-bundle-size:
-	@gzip -c packages/sdk/dist/index.js > packages/sdk/dist/index.js.gz
+	@gzip -c packages/sdk/dist/index.esm.js > packages/sdk/dist/index.esm.js.gz
 	@echo 'SDK package size:'
-	@ls -alh packages/sdk/dist | grep index.js | awk '{print $$9 "\t" $$5}'
+	@ls -alh packages/sdk/dist | grep index.esm.js | awk '{print $$9 "\t" $$5}'
 
 	@echo ''
 

--- a/docs/sdks/nodejs.md
+++ b/docs/sdks/nodejs.md
@@ -53,9 +53,7 @@ const { createInstance } = require("@featurevisor/sdk");
 If you want to take advantage of ES Modules, you can import the SDK directly:
 
 ```js
-import FeaturevisorSDK from "@featurevisor/sdk";
-
-const { createInstance } = FeaturevisorSDK;
+import { createInstance } from "@featurevisor/sdk";
 ```
 
 ## Example repository

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,7 +2,6 @@
   "name": "@featurevisor/sdk",
   "version": "1.20.0",
   "description": "Featurevisor SDK for Node.js and the browser",
-  "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "transpile": "echo 'Nothing to transpile'",
-    "dist": "webpack --config ./webpack.config.js && tsc --project tsconfig.esm.json --declaration --emitDeclarationOnly --outFile dist/index.d.ts",
+    "dist": "webpack --config ./webpack.config.js && tsc --project tsconfig.esm.json --declaration --emitDeclarationOnly --declarationDir dist",
     "build": "npm run transpile && npm run dist",
     "test": "jest --config jest.config.js --verbose --coverage",
     "format": "prettier . --check --cache --loglevel=warn",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,9 +2,15 @@
   "name": "@featurevisor/sdk",
   "version": "1.20.0",
   "description": "Featurevisor SDK for Node.js and the browser",
-  "main": "dist/index.js",
-  "module": "lib/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs.js"
+    }
+  },
   "scripts": {
     "transpile": "rimraf lib && tsc --project tsconfig.esm.json",
     "dist": "webpack --config ./webpack.config.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@featurevisor/sdk",
   "version": "1.20.0",
   "description": "Featurevisor SDK for Node.js and the browser",
+  "type": "module",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,19 +3,15 @@
   "version": "1.20.0",
   "description": "Featurevisor SDK for Node.js and the browser",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.esm.js"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
-      }
-    }
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "transpile": "echo 'Nothing to transpile'",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,16 +4,22 @@
   "description": "Featurevisor SDK for Node.js and the browser",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "types": "lib/index.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
-      "require": "./dist/index.cjs.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.esm.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs.js"
+      }
     }
   },
   "scripts": {
-    "transpile": "rimraf lib && tsc --project tsconfig.esm.json",
-    "dist": "webpack --config ./webpack.config.js",
+    "transpile": "echo 'Nothing to transpile'",
+    "dist": "webpack --config ./webpack.config.js && tsc --project tsconfig.esm.json --declaration --emitDeclarationOnly --outFile dist/index.d.ts",
     "build": "npm run transpile && npm run dist",
     "test": "jest --config jest.config.js --verbose --coverage",
     "format": "prettier . --check --cache --loglevel=warn",

--- a/packages/sdk/webpack.config.js
+++ b/packages/sdk/webpack.config.js
@@ -1,13 +1,82 @@
 const path = require("path");
 
-const getWebpackConfig = require("../../tools/getWebpackConfig");
+module.exports = [
+  // cjs
+  {
+    entry: {
+      "index.cjs": path.join(__dirname, "src", "index.ts"),
+    },
+    output: {
+      path: path.join(__dirname, "dist"),
+      filename: "index.cjs.js",
+      library: "FeaturevisorSDK",
+      libraryTarget: "umd",
+      globalObject: "this",
+    },
+    mode: "production",
+    devtool: "source-map",
+    resolve: {
+      extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx)$/,
+          exclude: /(node_modules)/,
+          use: [
+            {
+              loader: "ts-loader",
+              options: {
+                configFile: path.join(__dirname, "tsconfig.cjs.json"),
+                transpileOnly: true,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    performance: {
+      hints: false,
+    },
+    optimization: {
+      minimize: true,
+    },
+  },
 
-const wepbackConfig = getWebpackConfig({
-  entryFilePath: path.join(__dirname, "src", "index.ts"),
-  entryKey: "index",
-  outputDirectoryPath: path.join(__dirname, "dist"),
-  outputLibrary: "FeaturevisorSDK",
-  tsConfigFilePath: path.join(__dirname, "tsconfig.cjs.json"),
-});
-
-module.exports = wepbackConfig;
+  // esm
+  {
+    entry: {
+      "index.esm": path.join(__dirname, "src", "index.ts"),
+    },
+    output: {
+      path: path.join(__dirname, "dist"),
+      filename: "index.esm.js",
+      library: {
+        type: "module",
+      },
+    },
+    experiments: {
+      outputModule: true,
+    },
+    mode: "production",
+    devtool: "source-map",
+    resolve: {
+      extensions: [".ts", ".tsx", ".js"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx)$/,
+          exclude: /(node_modules)/,
+          loader: "ts-loader",
+          options: {
+            configFile: path.join(__dirname, "tsconfig.esm.json"),
+          },
+        },
+      ],
+    },
+    performance: {
+      hints: false,
+    },
+  },
+];

--- a/packages/sdk/webpack.config.js
+++ b/packages/sdk/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = [
     },
     output: {
       path: path.join(__dirname, "dist"),
-      filename: "index.cjs.js",
+      filename: "index.js",
       library: "FeaturevisorSDK",
       libraryTarget: "umd",
       globalObject: "this",
@@ -45,12 +45,10 @@ module.exports = [
 
   // esm
   {
-    entry: {
-      "index.esm": path.join(__dirname, "src", "index.ts"),
-    },
+    entry: path.join(__dirname, "src", "index.ts"),
     output: {
       path: path.join(__dirname, "dist"),
-      filename: "index.esm.js",
+      filename: "index.mjs",
       library: {
         type: "module",
       },

--- a/packages/vue/jest.config.js
+++ b/packages/vue/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
 
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect", "./jest.setup.js"],
+  moduleNameMapper: {
+    "^@featurevisor/sdk$": "<rootDir>/../sdk/src",
+  },
 };

--- a/tools/getWebpackConfig.js
+++ b/tools/getWebpackConfig.js
@@ -22,6 +22,9 @@ module.exports = function getWebpackConfig(options) {
     externals,
     devServer,
     plugins,
+
+    // new option for bundle type
+    bundleType,
   } = options;
 
   const entry = {};
@@ -33,7 +36,7 @@ module.exports = function getWebpackConfig(options) {
       path: outputDirectoryPath,
       filename: outputFileName || "[name].js",
       library: outputLibrary,
-      libraryTarget: outputLibraryTarget || "umd",
+      libraryTarget: outputLibraryTarget || (bundleType === "esm" ? "module" : "umd"),
       globalObject: "this",
     },
     devServer,
@@ -54,12 +57,22 @@ module.exports = function getWebpackConfig(options) {
           exclude: /(node_modules)/,
           loader: "ts-loader",
           options: {
-            configFile: tsConfigFilePath || path.join(__dirname, "..", "tsconfig.cjs.json"),
+            configFile:
+              tsConfigFilePath ||
+              (bundleType === "esm"
+                ? path.join(__dirname, "..", "tsconfig.esm.json")
+                : path.join(__dirname, "..", "tsconfig.cjs.json")),
           },
         },
       ],
     },
   };
+
+  if (bundleType === "esm") {
+    config.experiments = {
+      outputModule: true,
+    };
+  }
 
   if (enableCssModules) {
     config.resolve.extensions = [...config.resolve.extensions, ".css"];

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "sourceMap": true,
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "jsx": "react"
   },
   "include": ["./packages/**/*.ts", "./packages/**/*.tsx"],
   "exclude": ["./packages/**/*.spec.ts", "./packages/**/*.spec.tsx"]

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "target": "es5",
-    "lib": ["es2015"],
-    "module": "es2015",
+    "target": "es2015",
+    "lib": ["es2015", "DOM"],
+    "module": "ESNext",
     "declaration": true,
     "sourceMap": true,
-    "jsx": "react",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "esModuleInterop": true
   },
   "include": ["./packages/**/*.ts", "./packages/**/*.tsx"],
   "exclude": ["./packages/**/*.spec.ts", "./packages/**/*.spec.tsx"]


### PR DESCRIPTION
## What's done

Continuing from https://github.com/featurevisor/featurevisor/pull/322

Next to existing CommonJS build, a new ESM build is also produced with Webpack.

This should ideally fix the issues experienced in:

- https://github.com/featurevisor/featurevisor/pull/321
- https://github.com/featurevisor/featurevisor/issues/312
- https://github.com/featurevisor/featurevisor/issues/269

cc @meirroth 

## TODOs

- [x] Try it out locally against https://github.com/featurevisor/featurevisor-example-nodejs by doing `import { createInstance } from "@featurevisor/sdk";`