### PR TITLE
chore: update json schemas to match examples

### DIFF
--- a/packages/core/json-schema/feature.json
+++ b/packages/core/json-schema/feature.json
@@ -65,47 +65,54 @@
           "maximum": 100
         },
         "variables": {
-          "type": "object",
-          "properties": {
-            "key": {
-              "type": "string",
-              "description": "Key of the variable."
-            },
-            "value": {
-              "$ref": "#/$defs/variable_value",
-              "description": "Value of the variable."
-            },
-            "overrides": {
-              "type": "object",
-              "properties": {
-                "conditions": {
-                  "$ref": "segment.json#/$defs/multiple_conditions",
-                  "description": "Embedded conditions for overriding the variable"
-                },
-                "segments": {
-                  "$ref": "#/$defs/segments",
-                  "description": "Embedded conditions for overriding the variable"
-                },
-                "value": {
-                  "$ref": "#/$defs/variable_value",
-                  "description": "Value of the override."
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "Key of the variable."
               },
-              "required": ["value"]
-            }
-          },
-          "description": "Variables for the variation.",
-          "required": ["key"]
+              "value": {
+                "$ref": "#/$defs/variable_value",
+                "description": "Value of the variable."
+              },
+              "overrides": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "conditions": {
+                      "$ref": "segment.json#/$defs/multiple_conditions",
+                      "description": "Embedded conditions for overriding the variable"
+                    },
+                    "segments": {
+                      "$ref": "#/$defs/segments",
+                      "description": "Embedded conditions for overriding the variable"
+                    },
+                    "value": {
+                      "$ref": "#/$defs/variable_value",
+                      "description": "Value of the override."
+                    }
+                  },
+                  "required": ["value"]
+                }
+              }
+            },
+            "description": "Variables for the variation.",
+            "required": ["key"]
+          }
         }
       },
       "description": "Variation for the feature.",
       "required": ["value"]
     },
     "segments": {
-      "oneOf": [
+      "anyOf": [
         { "$ref": "#/$defs/segments_everyone" },
         { "$ref": "#/$defs/segments_multiple" },
-        { "$ref": "#/$defs/segments_complex" }
+        { "$ref": "#/$defs/segments_complex" },
+        { "$ref": "#/$defs/segments_single" }
       ],
       "description": "Array of segment keys"
     },
@@ -185,24 +192,27 @@
       "description": "Default variation for the feature."
     },
     "variablesSchema": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "Key of the variable."
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key of the variable."
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of this specific variable.",
+            "enum": ["string", "boolean", "integer", "double", "json", "array", "object"]
+          },
+          "defaultValue": {
+            "$ref": "#/$defs/variable_value",
+            "description": "Default value for this specific variable."
+          }
         },
-        "type": {
-          "type": "string",
-          "description": "Type of this specific variable.",
-          "enum": ["string", "boolean", "integer", "double", "json", "array", "object"]
-        },
-        "defaultValue": {
-          "$ref": "#/$defs/variable_value",
-          "description": "Default value for this specific variable."
-        }
-      },
-      "description": "Schema for the feature's variables.",
-      "required": ["type"]
+        "description": "Schema for the feature's variables.",
+        "required": ["type"]
+      }
     },
     "variations": {
       "type": "array",
@@ -263,7 +273,17 @@
                   "description": "Embedded segments"
                 },
                 "conditions": {
-                  "$ref": "segment.json#/$defs/multiple_conditions"
+                  "oneOf": [
+                    {
+                      "$ref": "segment.json#/$defs/multiple_conditions"
+                    },
+                    {
+                      "$ref": "segment.json#/$defs/complex_condition"
+                    },
+                    {
+                      "$ref": "segment.json#/$defs/plain_condition"
+                    }
+                  ]
                 },
                 "variation": {
                   "$ref": "#/$defs/variation_value",
@@ -285,5 +305,5 @@
     }
   },
   "description": "JSON Schema for creating Featurevisor feature, expressed in YAML",
-  "required": ["description", "tags", "defaultVariation", "variations"]
+  "required": ["description", "tags"]
 }

--- a/packages/core/json-schema/segment.json
+++ b/packages/core/json-schema/segment.json
@@ -19,7 +19,7 @@
           "description": "Operator to be used in the condition. Allowed values are: equals, notEquals, greaterThan, greaterThanOrEquals, lessThan, lessThanOrEquals, contains, notContains, startsWith, endsWith, semverEquals, semverNotEquals, semverGreaterThan, semverGreaterThanOrEquals, semverLessThan, semverLessThanOrEquals, in, notIn."
         },
         "value": {
-          "type": ["string", "number", "boolean", "array"],
+          "type": ["string", "number", "boolean", "array", "null"],
           "description": "Value to be used in the condition. Can be a string, number, boolean, or array of strings."
         }
       },
@@ -40,7 +40,7 @@
           "type": "array",
           "items": {
             "anyOf": [
-              { "$ref": "#/$defs/simple_condition" },
+              { "$ref": "#/$defs/plain_condition" },
               { "$ref": "#/$defs/complex_condition" }
             ]
           },
@@ -56,7 +56,7 @@
           "type": "array",
           "items": {
             "anyOf": [
-              { "$ref": "#/$defs/simple_condition" },
+              { "$ref": "#/$defs/plain_condition" },
               { "$ref": "#/$defs/complex_condition" }
             ]
           },
@@ -72,7 +72,7 @@
           "type": "array",
           "items": {
             "anyOf": [
-              { "$ref": "#/$defs/simple_condition" },
+              { "$ref": "#/$defs/plain_condition" },
               { "$ref": "#/$defs/complex_condition" }
             ]
           },
@@ -93,7 +93,11 @@
       "description": "Human readable description of the segment for documentation purposes."
     },
     "conditions": {
-      "oneOf": [{ "$ref": "#/$defs/multiple_conditions" }, { "$ref": "#/$defs/complex_condition" }],
+      "oneOf": [
+        { "$ref": "#/$defs/multiple_conditions" },
+        { "$ref": "#/$defs/complex_condition" },
+        { "$ref": "#/$defs/plain_condition" }
+      ],
       "description": "The set of conditions to be evaluated for the segment."
     }
   },


### PR DESCRIPTION
# Overview

This PR resolves issues with JSON schema definitions so that they are compatible with all existing examples.

* Fixed broken reference to `plain_condition`
* Made `defaultVariation` and `variations` optional for features
* etc.


# Notes
Here are the contents of the `.vscode/settings.json` configuration that helped to enable the intellisense and catch the errors. 

I also have 

I considered adding this into the project so it becomes a first-class concern as new features are being developed, but I'll leave it up to @fahad19 to decide if it belongs in this repo or only in user-land!

Thanks for working on this library!

```json
{
  "yaml.schemas": {
    "packages/core/json-schema/feature.json": "/features/*",
    "packages/core/json-schema/segment.json": "/segments/*",
    "packages/core/json-schema/attribute.json": "/attributes/*"
  },
  "json.schemas": [
    {
      "fileMatch": ["/features/*"],
      "url": "./packages/core/json-schema/feature.json"
    },
    {
      "fileMatch": ["/segments/*"],
      "url": "./packages/core/json-schema/segment.json"
    },
    {
      "fileMatch": ["/attributes/*"],
      "url": "./packages/core/json-schema/attribute.json"
    }
  ]
}
```
# Screenshots

**Before**

![Screen Recording 2024-10-02 at 11 06 23 PM](https://github.com/user-attachments/assets/6df698fd-ade4-41ba-965f-ff092bd97819)



**After**

![Screen Recording 2024-10-02 at 11 05 10 PM](https://github.com/user-attachments/assets/4171e974-b451-42b2-8d0e-b7c9479594db)





