### PR TITLE
fix: non-existent property in context when checking in and noIn conditions

### DIFF
--- a/examples/example-1/attributes/continent.yml
+++ b/examples/example-1/attributes/continent.yml
@@ -1,0 +1,2 @@
+description: continent name
+type: string

--- a/examples/example-1/segments/eu.yml
+++ b/examples/example-1/segments/eu.yml
@@ -1,0 +1,10 @@
+description: EU
+conditions:
+  - attribute: continent
+    operator: equals
+    value: europe
+
+  - attribute: country
+    operator: notIn
+    value:
+      - gb

--- a/examples/example-1/tests/eu.spec.yml
+++ b/examples/example-1/tests/eu.spec.yml
@@ -1,19 +1,46 @@
 segment: eu
 assertions:
-  - context:
+  - description: continent is europe, with no country passed should still match
+    context:
       continent: europe
     expectedToMatch: true
 
-  - context:
+  - description: continent is asia, so not matching early
+    context:
       continent: "asia"
     expectedToMatch: false
 
-  - context:
+  - description: continent is europe, country is nl, should match
+    context:
       continent: europe
       country: nl
     expectedToMatch: true
 
-  - context:
+  - description: continent is europe, country is gb, which is known to be not in EU, therefore should not match
+    context:
       continent: europe
       country: gb
     expectedToMatch: false
+
+  # passing unexpected values in `country`
+  - context:
+      continent: europe
+      country:
+        a: a
+        b: b
+    expectedToMatch: true
+
+  - context:
+      continent: europe
+      country: [a, b, c]
+    expectedToMatch: true
+
+  - context:
+      continent: europe
+      country: 100
+    expectedToMatch: true
+
+  - context:
+      continent: europe
+      country: null
+    expectedToMatch: true

--- a/examples/example-1/tests/eu.spec.yml
+++ b/examples/example-1/tests/eu.spec.yml
@@ -1,0 +1,19 @@
+segment: eu
+assertions:
+  - context:
+      continent: europe
+    expectedToMatch: true
+
+  - context:
+      continent: "asia"
+    expectedToMatch: false
+
+  - context:
+      continent: europe
+      country: nl
+    expectedToMatch: true
+
+  - context:
+      continent: europe
+      country: gb
+    expectedToMatch: false

--- a/packages/sdk/src/conditions.ts
+++ b/packages/sdk/src/conditions.ts
@@ -22,7 +22,7 @@ export function conditionIsMatched(condition: PlainCondition, context: Context):
     return operator === "before"
       ? dateInContext < dateInCondition
       : dateInContext > dateInCondition;
-  } else if (typeof context[attribute] === "string" && Array.isArray(value)) {
+  } else if (Array.isArray(value)) {
     // array
     const valueInContext = context[attribute] as string;
 


### PR DESCRIPTION
## Issue

- we may use `notIn` operator in conditions inside a segment against an attribute
- but we may not ALWAYS pass that attribute in context when evaluating values with SDKs
- in those cases, notIn should still match because the value in context is not any of the strings in provided list in segment

## Reproduction

- test spec added by creating a new `eu` segment
- it will match if `continent = 'europe' AND country != 'gb'`
- it should still match if `content = 'europe'` AND `country` is never passed in the context

## Fix

When dealing with `array` values in conditions (applies to `in` and `notIn` operators only), we had an extra check in SDK to see if the corresponding attribute's value is of type `string` in the given context.

Which made sense because we are only expecting to deal with an array of strings.

But there can be cases when the attribute is never passed in the context.

Because non-existent property would be of type `undefined` in JavaScript, the `if` block (see diff) never triggered and therefore our conditions were not matching as expected.

This extra type check for type `string` is now removed, and everything works as expected.