### PR TITLE
feat: datafile schema v2

### DIFF
--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -75,3 +75,13 @@ $ npx featurevisor build --environment=production --print --pretty
 This is useful primarily for debugging and testing purposes.
 
 If you are an SDK developer in other languages besides JavaScript, you may want to use this handy command to get the generated datafile content in JSON format that you can use in your own [test runner](/docs/testing).
+
+## Schema v2
+
+In preparation for the upcoming [major v2.0](https://github.com/featurevisor/featurevisor/issues/326) release, current Featurevisor v1.x CLI can optionally build datafiles in the new schema format. To enable this, you can pass the `--schema-version=2` flag:
+
+```
+$ npx featurevisor build --schema-version=2
+```
+
+Before generating datafiles in the new schema format, make sure to upgrade to latest Featurevisor SDK in your client application(s) which supports both schema versions.

--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -86,4 +86,4 @@ To enable this, you can pass `--schema-version=2` in CLI:
 $ npx featurevisor build --schema-version=2
 ```
 
-Before generating datafiles in the new schema format, make sure to upgrade to latest Featurevisor SDKs in your client application(s) which supports both schema versions.
+Before generating datafiles in the new schema format, make sure to upgrade to latest Featurevisor SDKs in your client application(s) which support both schema versions.

--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -78,10 +78,12 @@ If you are an SDK developer in other languages besides JavaScript, you may want 
 
 ## Schema v2
 
-In preparation for the upcoming [major v2.0](https://github.com/featurevisor/featurevisor/issues/326) release, current Featurevisor v1.x CLI can optionally build datafiles in the new schema format. To enable this, you can pass the `--schema-version=2` flag:
+In preparation for the upcoming [major v2.0](https://github.com/featurevisor/featurevisor/issues/326) release, current Featurevisor v1.x CLI can optionally build datafiles in the new schema format.
+
+To enable this, you can pass `--schema-version=2` in CLI:
 
 ```
 $ npx featurevisor build --schema-version=2
 ```
 
-Before generating datafiles in the new schema format, make sure to upgrade to latest Featurevisor SDK in your client application(s) which supports both schema versions.
+Before generating datafiles in the new schema format, make sure to upgrade to latest Featurevisor SDKs in your client application(s) which supports both schema versions.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -200,6 +200,8 @@ $ npx featurevisor benchmark \
   --n=1000
 ```
 
+You can optionally pass `--schema-version=2` if you are using the new schema v2.
+
 ## Configuration
 
 To view the project [configuration](/docs/configuration):
@@ -251,6 +253,8 @@ $ npx featurevisor evaluate \
   --context='{"userId": "123", "country": "nl"}' \
   --verbose
 ```
+
+You can optionally pass `--schema-version=2` if you are using the new schema v2.
 
 ## Assess distribution
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -609,6 +609,14 @@ When [variables](#variable) are defined inside a feature, they must also provide
 
 Learn more about variables schema [here](/docs/features/#variables).
 
+## Schema version
+
+Generated [datafiles](#datafile) follow a schema version.
+
+Featurevisor started with the schema version of 1, and a new schema version 2 is in the works.
+
+See how you can build datafiles against a more optimized schema version [here](/docs/building-datafiles/#schema-v2).
+
 ## SDK
 
 SDK stands for Software Development Kit.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -216,6 +216,14 @@ $ npx featurevisor test --onlyFailures
 
 This option has been deprecated, because test runner is now fast by default.
 
+### `schema-version`
+
+If you are using the new schema v2, you can specify it like this:
+
+```
+$ npx featurevisor test --schema-version=2
+```
+
 ## NPM scripts
 
 If you are using npm scripts for testing your Featurevisor project like this:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -218,7 +218,7 @@ This option has been deprecated, because test runner is now fast by default.
 
 ### `schema-version`
 
-If you are using the new schema v2, you can specify it like this:
+If you are using the new [schema v2](/docs/building-datafiles/#schema-v2), you can specify it like this:
 
 ```
 $ npx featurevisor test --schema-version=2

--- a/examples/example-1/Makefile
+++ b/examples/example-1/Makefile
@@ -23,4 +23,5 @@ test-datafiles:
 
 test:
 	npx featurevisor test
+	npx featurevisor test --schema-version=2
 	make test-datafiles

--- a/packages/core/src/assess-distribution/index.ts
+++ b/packages/core/src/assess-distribution/index.ts
@@ -72,6 +72,7 @@ export interface AssessDistributionOptions {
   context: Context;
   n: number;
   schemaVersion?: string;
+  inflate?: number;
 
   populateUuid?: AttributeKey[];
   verbose?: boolean;
@@ -95,6 +96,7 @@ export async function assessDistribution(deps: Dependencies, options: AssessDist
       schemaVersion: options.schemaVersion || SCHEMA_VERSION,
       revision: "include-all-features",
       environment: options.environment,
+      inflate: options.inflate,
     },
     existingState,
   );

--- a/packages/core/src/assess-distribution/index.ts
+++ b/packages/core/src/assess-distribution/index.ts
@@ -71,6 +71,7 @@ export interface AssessDistributionOptions {
   feature: FeatureKey;
   context: Context;
   n: number;
+  schemaVersion?: string;
 
   populateUuid?: AttributeKey[];
   verbose?: boolean;
@@ -91,7 +92,7 @@ export async function assessDistribution(deps: Dependencies, options: AssessDist
     projectConfig,
     datasource,
     {
-      schemaVersion: SCHEMA_VERSION,
+      schemaVersion: options.schemaVersion || SCHEMA_VERSION,
       revision: "include-all-features",
       environment: options.environment,
     },

--- a/packages/core/src/benchmark/index.ts
+++ b/packages/core/src/benchmark/index.ts
@@ -99,9 +99,6 @@ export async function benchmarkFeature(
   console.log("");
 
   console.log(`Building datafile containing all features for "${options.environment}"...`);
-  if (options.inflate) {
-    console.log(`Inflating datafile by ${options.inflate} times to increase its size...`);
-  }
   const datafileBuildStart = Date.now();
   const existingState = await datasource.readState(options.environment);
   const datafileContent = await buildDatafile(
@@ -118,6 +115,13 @@ export async function benchmarkFeature(
   const datafileBuildDuration = Date.now() - datafileBuildStart;
   console.log(`Datafile build duration: ${datafileBuildDuration}ms`);
   console.log(`Datafile size: ${(JSON.stringify(datafileContent).length / 1024).toFixed(2)} kB`);
+
+  if (options.inflate) {
+    console.log("");
+    console.log("Features count:", Object.keys(datafileContent.features).length);
+    console.log("Segments count:", Object.keys(datafileContent.segments).length);
+    console.log("Attributes count:", Object.keys(datafileContent.attributes).length);
+  }
 
   console.log("");
 

--- a/packages/core/src/benchmark/index.ts
+++ b/packages/core/src/benchmark/index.ts
@@ -83,6 +83,7 @@ export interface BenchmarkOptions {
   context: Record<string, unknown>;
   variation?: boolean;
   variable?: string;
+  schemaVersion?: string;
 }
 
 export async function benchmarkFeature(
@@ -103,7 +104,7 @@ export async function benchmarkFeature(
     projectConfig,
     datasource,
     {
-      schemaVersion: SCHEMA_VERSION,
+      schemaVersion: options.schemaVersion || SCHEMA_VERSION,
       revision: "include-all-features",
       environment: options.environment,
     },

--- a/packages/core/src/benchmark/index.ts
+++ b/packages/core/src/benchmark/index.ts
@@ -84,6 +84,7 @@ export interface BenchmarkOptions {
   variation?: boolean;
   variable?: string;
   schemaVersion?: string;
+  inflate?: number;
 }
 
 export async function benchmarkFeature(
@@ -107,6 +108,7 @@ export async function benchmarkFeature(
       schemaVersion: options.schemaVersion || SCHEMA_VERSION,
       revision: "include-all-features",
       environment: options.environment,
+      inflate: options.inflate,
     },
     existingState,
   );

--- a/packages/core/src/benchmark/index.ts
+++ b/packages/core/src/benchmark/index.ts
@@ -99,6 +99,9 @@ export async function benchmarkFeature(
   console.log("");
 
   console.log(`Building datafile containing all features for "${options.environment}"...`);
+  if (options.inflate) {
+    console.log(`Inflating datafile by ${options.inflate} times to increase its size...`);
+  }
   const datafileBuildStart = Date.now();
   const existingState = await datasource.readState(options.environment);
   const datafileContent = await buildDatafile(
@@ -114,6 +117,7 @@ export async function benchmarkFeature(
   );
   const datafileBuildDuration = Date.now() - datafileBuildStart;
   console.log(`Datafile build duration: ${datafileBuildDuration}ms`);
+  console.log(`Datafile size: ${(JSON.stringify(datafileContent).length / 1024).toFixed(2)} kB`);
 
   console.log("");
 
@@ -170,6 +174,8 @@ export const benchmarkPlugin: Plugin = {
         context: parsed.context ? JSON.parse(parsed.context) : {},
         variation: parsed.variation || undefined,
         variable: parsed.variable || undefined,
+        schemaVersion: parsed.schemaVersion || undefined,
+        inflate: parseInt(parsed.inflate, 10) || undefined,
       },
     );
   },

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -7,6 +7,7 @@ import { Plugin } from "../cli";
 
 export interface BuildCLIOptions {
   revision?: string;
+  schemaVersion?: string;
 
   // all three together
   environment?: string;
@@ -36,6 +37,7 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
       projectConfig,
       datasource,
       revision: cliOptions.revision,
+      schemaVersion: cliOptions.schemaVersion,
     });
 
     if (cliOptions.pretty) {
@@ -71,7 +73,7 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
         projectConfig,
         datasource,
         {
-          schemaVersion: SCHEMA_VERSION,
+          schemaVersion: cliOptions.schemaVersion || SCHEMA_VERSION,
           revision: nextRevision,
           environment: environment,
           tag: tag,
@@ -101,6 +103,11 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
 export const buildPlugin: Plugin = {
   command: "build",
   handler: async function ({ rootDirectoryPath, projectConfig, datasource, parsed }) {
+    // @TODO: in future, allow yargs options to be defined via plugins
+    if (parsed.schemaVersion && typeof parsed.schemaVersion !== "string") {
+      parsed.schemaVersion = parsed.schemaVersion.toString();
+    }
+
     await buildProject(
       {
         rootDirectoryPath,

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -103,11 +103,6 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
 export const buildPlugin: Plugin = {
   command: "build",
   handler: async function ({ rootDirectoryPath, projectConfig, datasource, parsed }) {
-    // @TODO: in future, allow yargs options to be defined via plugins
-    if (parsed.schemaVersion && typeof parsed.schemaVersion !== "string") {
-      parsed.schemaVersion = parsed.schemaVersion.toString();
-    }
-
     await buildProject(
       {
         rootDirectoryPath,

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -15,6 +15,7 @@ export interface BuildCLIOptions {
   print?: boolean;
   pretty?: boolean;
   stateFiles?: boolean; // --no-state-files in CLI
+  inflate?: number;
 }
 
 export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptions = {}) {
@@ -77,6 +78,7 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
           revision: nextRevision,
           environment: environment,
           tag: tag,
+          inflate: cliOptions.inflate,
         },
         existingState,
       );

--- a/packages/core/src/cli/cli.ts
+++ b/packages/core/src/cli/cli.ts
@@ -51,6 +51,11 @@ export async function runCLI(runnerOptions: RunnerOptions) {
     y = y.command({
       command: plugin.command,
       handler: async function (parsed: ParsedOptions) {
+        // @TODO: in future, allow yargs options to be defined via plugins
+        if (parsed.schemaVersion && typeof parsed.schemaVersion !== "string") {
+          parsed.schemaVersion = parsed.schemaVersion.toString();
+        }
+
         try {
           const result = await plugin.handler({
             rootDirectoryPath,

--- a/packages/core/src/config/projectConfig.ts
+++ b/packages/core/src/config/projectConfig.ts
@@ -27,7 +27,7 @@ export const DEFAULT_PRETTY_DATAFILE = false;
 
 export const DEFAULT_PARSER: Parser = "yml";
 
-export const SCHEMA_VERSION = "1";
+export const SCHEMA_VERSION = "1"; // default schema version
 
 export interface ProjectConfig {
   featuresDirectoryPath: string;

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -56,6 +56,7 @@ export interface EvaluateOptions {
   print?: boolean;
   pretty?: boolean;
   verbose?: boolean;
+  schemaVersion?: string;
 }
 
 export interface Log {
@@ -72,7 +73,7 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
     projectConfig,
     datasource,
     {
-      schemaVersion: SCHEMA_VERSION,
+      schemaVersion: options.schemaVersion || SCHEMA_VERSION,
       revision: "include-all-features",
       environment: options.environment,
     },

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -57,6 +57,7 @@ export interface EvaluateOptions {
   pretty?: boolean;
   verbose?: boolean;
   schemaVersion?: string;
+  inflate?: number;
 }
 
 export interface Log {
@@ -76,6 +77,7 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
       schemaVersion: options.schemaVersion || SCHEMA_VERSION,
       revision: "include-all-features",
       environment: options.environment,
+      inflate: options.inflate,
     },
     existingState,
   );

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -19,6 +19,7 @@ export interface TestProjectOptions {
   verbose?: boolean;
   showDatafile?: boolean;
   onlyFailures?: boolean;
+  schemaVersion?: string;
 }
 
 export interface TestPatterns {
@@ -157,7 +158,7 @@ export async function testProject(
       projectConfig,
       datasource,
       {
-        schemaVersion: SCHEMA_VERSION,
+        schemaVersion: options.schemaVersion || SCHEMA_VERSION,
         revision: "include-all-features",
         environment: environment,
       },
@@ -216,6 +217,10 @@ export async function testProject(
 export const testPlugin: Plugin = {
   command: "test",
   handler: async function ({ rootDirectoryPath, projectConfig, datasource, parsed }) {
+    if (parsed.schemaVersion && typeof parsed.schemaVersion !== "string") {
+      parsed.schemaVersion = parsed.schemaVersion.toString();
+    }
+
     const hasError = await testProject(
       {
         rootDirectoryPath,

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -20,6 +20,7 @@ export interface TestProjectOptions {
   showDatafile?: boolean;
   onlyFailures?: boolean;
   schemaVersion?: string;
+  inflate?: number;
 }
 
 export interface TestPatterns {
@@ -161,6 +162,7 @@ export async function testProject(
         schemaVersion: options.schemaVersion || SCHEMA_VERSION,
         revision: "include-all-features",
         environment: environment,
+        inflate: options.inflate,
       },
       existingState,
     );

--- a/packages/core/src/tester/testProject.ts
+++ b/packages/core/src/tester/testProject.ts
@@ -217,10 +217,6 @@ export async function testProject(
 export const testPlugin: Plugin = {
   command: "test",
   handler: async function ({ rootDirectoryPath, projectConfig, datasource, parsed }) {
-    if (parsed.schemaVersion && typeof parsed.schemaVersion !== "string") {
-      parsed.schemaVersion = parsed.schemaVersion.toString();
-    }
-
     const hasError = await testProject(
       {
         rootDirectoryPath,

--- a/packages/sdk/src/datafileReader.ts
+++ b/packages/sdk/src/datafileReader.ts
@@ -1,7 +1,8 @@
 import {
   Feature,
   Segment,
-  DatafileContent,
+  DatafileContentV1,
+  DatafileContentV2,
   Attribute,
   AttributeKey,
   SegmentKey,
@@ -23,16 +24,34 @@ export function parseJsonConditionsIfStringified<T>(record: T, key: string): T {
 export class DatafileReader {
   private schemaVersion: string;
   private revision: string;
+
+  // v1
   private attributes: Attribute[];
   private segments: Segment[];
   private features: Feature[];
 
-  constructor(datafileJson: DatafileContent) {
+  // v2
+  private attributesV2: Record<AttributeKey, Attribute>;
+  private segmentsV2: Record<SegmentKey, Segment>;
+  private featuresV2: Record<FeatureKey, Feature>;
+
+  constructor(datafileJson: DatafileContentV1 | DatafileContentV2) {
     this.schemaVersion = datafileJson.schemaVersion;
     this.revision = datafileJson.revision;
-    this.segments = datafileJson.segments;
-    this.attributes = datafileJson.attributes;
-    this.features = datafileJson.features;
+
+    if (this.schemaVersion === "2") {
+      const datafileJsonV2 = datafileJson as DatafileContentV2;
+
+      this.attributesV2 = datafileJsonV2.attributes;
+      this.segmentsV2 = datafileJsonV2.segments;
+      this.featuresV2 = datafileJsonV2.features;
+    } else {
+      const datafileJsonV1 = datafileJson as DatafileContentV1;
+
+      this.segments = datafileJsonV1.segments;
+      this.attributes = datafileJsonV1.attributes;
+      this.features = datafileJsonV1.features;
+    }
   }
 
   getRevision(): string {
@@ -44,14 +63,33 @@ export class DatafileReader {
   }
 
   getAllAttributes(): Attribute[] {
-    return this.attributes;
+    if (this.schemaVersion !== "2") {
+      return this.attributes;
+    }
+
+    // v2
+    const result: Attribute[] = [];
+
+    for (const key in this.attributesV2) {
+      result.push(this.attributesV2[key]);
+    }
+
+    return result;
   }
 
   getAttribute(attributeKey: AttributeKey): Attribute | undefined {
+    if (this.schemaVersion === "2") {
+      return this.attributesV2[attributeKey];
+    }
+
     return this.attributes.find((a) => a.key === attributeKey);
   }
 
   getSegment(segmentKey: SegmentKey): Segment | undefined {
+    if (this.schemaVersion === "2") {
+      return this.segmentsV2[segmentKey];
+    }
+
     const segment = this.segments.find((s) => s.key === segmentKey);
 
     if (!segment) {
@@ -62,6 +100,10 @@ export class DatafileReader {
   }
 
   getFeature(featureKey: FeatureKey): Feature | undefined {
+    if (this.schemaVersion === "2") {
+      return this.featuresV2[featureKey];
+    }
+
     const feature = this.features.find((s) => s.key === featureKey);
 
     if (!feature) {

--- a/packages/sdk/src/datafileReader.ts
+++ b/packages/sdk/src/datafileReader.ts
@@ -86,11 +86,10 @@ export class DatafileReader {
   }
 
   getSegment(segmentKey: SegmentKey): Segment | undefined {
-    if (this.schemaVersion === "2") {
-      return this.segmentsV2[segmentKey];
-    }
-
-    const segment = this.segments.find((s) => s.key === segmentKey);
+    const segment =
+      this.schemaVersion === "2"
+        ? this.segmentsV2[segmentKey]
+        : this.segments.find((s) => s.key === segmentKey);
 
     if (!segment) {
       return undefined;
@@ -100,11 +99,10 @@ export class DatafileReader {
   }
 
   getFeature(featureKey: FeatureKey): Feature | undefined {
-    if (this.schemaVersion === "2") {
-      return this.featuresV2[featureKey];
-    }
-
-    const feature = this.features.find((s) => s.key === featureKey);
+    const feature =
+      this.schemaVersion === "2"
+        ? this.featuresV2[featureKey]
+        : this.features.find((f) => f.key === featureKey);
 
     if (!feature) {
       return undefined;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -249,13 +249,29 @@ export interface Feature {
   ranges?: Range[]; // if in a Group (mutex), these are the available slot ranges
 }
 
-export interface DatafileContent {
+export interface DatafileContentV1 {
   schemaVersion: string;
   revision: string;
   attributes: Attribute[];
   segments: Segment[];
   features: Feature[];
 }
+
+export interface DatafileContentV2 {
+  schemaVersion: string;
+  revision: string;
+  attributes: {
+    [key: AttributeKey]: Attribute;
+  };
+  segments: {
+    [key: SegmentKey]: Segment;
+  };
+  features: {
+    [key: FeatureKey]: Feature;
+  };
+}
+
+export type DatafileContent = DatafileContentV1 | DatafileContentV2;
 
 export interface OverrideFeature {
   enabled: boolean;


### PR DESCRIPTION
**TL;DR**: more optimized datafiles, with initial benchmarks suggesting **~29x faster** evaluations by SDK.

![sdk_evaluation](https://github.com/user-attachments/assets/4185d011-289f-4944-9b49-a51b4f690038)

## What's done

- [x] Allow datafiles to optionally be built with optimizations (dictionaries for entities, instead of arrays), meaning we are moving from O(n) lookup to O(1)
- [x] Update internal plugins to pass optional custom `--schema-version=2` option from CLI to datafile builder
- [x] Update SDK to honour both `DatafileContentV1` (as it always existed) and `DatafileContentV2` (new)
- [x] Make `examples/example-1` tests pass
- [x] Benchmark both datafile schema versions to compare with an example project

If the numbers are good, merge.

## Benchmark

Tested against `examples/example-1` project running the evaluation **1 million** times:

### 🔴 With `DatafileContentV1`:

```
$ npx featurevisor benchmark --environment=production --feature=discount --context='{"country": "nl", "userId": "123"}' --n=1000000 --schema-version=1 --inflate=76

Running benchmark for feature "discount"...

Building datafile containing all features for "production"...
Datafile build duration: 17ms
Datafile size: 528.10 kB

Features count: 1001
Segments count: 539
Attributes count: 385

...SDK initialized

Against context: {"country":"nl","userId":"123"}
Evaluating flag 1000000 times...

Evaluated value : false
Total duration  : 12s 100ms
Average duration: 0.0121ms
```

### 🟢 With `DatafileContentV2` (optimized):

```
$ npx featurevisor benchmark --environment=production --feature=discount --context='{"country": "nl", "userId": "123"}' --n=1000000 --schema-version=2 --inflate=76

Running benchmark for feature "discount"...

Building datafile containing all features for "production"...
Datafile build duration: 19ms
Datafile size: 553.05 kB

Features count: 1001
Segments count: 539
Attributes count: 385

...SDK initialized

Against context: {"country":"nl","userId":"123"}
Evaluating flag 1000000 times...

Evaluated value : false
Total duration  : 1s 98ms
Average duration: 0.001098ms
```

### Summary

With the optimization, average evaluation duration went down from 0.029ms to 0.001ms (29x faster)

## Backwards compatibility

This paves the way for Featurevisor v2.0 in future, as noted in #326:

- Featurevisor v1.x will support both `DatafileContentV1` and `DatafileContentV2`
- Featurevisor v2.x will drop support for `DatafileContentV1`

To summarize, no breaking changes for anyone via this PR

## How to upgrade safely?

### Client applications

First, upgrade to latest `@featurevisor/sdk` npm package in your client applications first, which can support both schema versions together.

### Project repository

Then, from your Featurevisor project repository, upgrade to latest `@featurevisor/cli`. 

When building datafiles, pass `--schema-version=2`:

```
$ npx featurevisor build --schema-version=2
```

To gain additional confidence, you can run your tests against datafiles built with schema v2 as well:

```
$ npx featurevisor test --schema-version=2
```