### PR TITLE
fix: in operator with non-existent context value

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Fahad Heylaal (https://fahad19.com)
+Copyright (c) 2025 Fahad Heylaal (https://fahad19.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/example-1/tests/eu.spec.yml
+++ b/examples/example-1/tests/eu.spec.yml
@@ -1,9 +1,9 @@
 segment: eu
 assertions:
-  - description: continent is europe, with no country passed should still match
+  - description: continent is europe, with no country passed should not match
     context:
       continent: europe
-    expectedToMatch: true
+    expectedToMatch: false
 
   - description: continent is asia, so not matching early
     context:
@@ -28,12 +28,12 @@ assertions:
       country:
         a: a
         b: b
-    expectedToMatch: true
+    expectedToMatch: false
 
   - context:
       continent: europe
       country: [a, b, c]
-    expectedToMatch: true
+    expectedToMatch: false
 
   - context:
       continent: europe

--- a/packages/sdk/src/conditions.ts
+++ b/packages/sdk/src/conditions.ts
@@ -22,7 +22,10 @@ export function conditionIsMatched(condition: PlainCondition, context: Context):
     return operator === "before"
       ? dateInContext < dateInCondition
       : dateInContext > dateInCondition;
-  } else if (Array.isArray(value)) {
+  } else if (
+    Array.isArray(value) &&
+    (["string", "number"].indexOf(typeof context[attribute]) !== -1 || context[attribute] === null)
+  ) {
     // array
     const valueInContext = context[attribute] as string;
 


### PR DESCRIPTION
Continuation of the fix from https://github.com/featurevisor/featurevisor/pull/328