### PR TITLE
feat: pass custom datafiles directory path from CLI

### DIFF
--- a/docs/building-datafiles.md
+++ b/docs/building-datafiles.md
@@ -76,6 +76,16 @@ This is useful primarily for debugging and testing purposes.
 
 If you are an SDK developer in other languages besides JavaScript, you may want to use this handy command to get the generated datafile content in JSON format that you can use in your own [test runner](/docs/testing).
 
+## Datafiles directory
+
+By default, datafiles will be generated in the `dist` directory, or your custom directory if you have specified it under `outputDirectoryPath` in your [`featurevisor.config.js`](/docs/configuration/) file.
+
+You can optionally override it from CLI:
+
+```
+$ npx featurevisor build --datafiles-dir=./custom-directory
+```
+
 ## Schema v2
 
 In preparation for the upcoming [major v2.0](https://github.com/featurevisor/featurevisor/issues/326) release, current Featurevisor v1.x CLI can optionally build datafiles in the new schema format.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,33 +23,39 @@ As your tags and environments grow, you can keep adding them to your configurati
 
 ### `attributesDirectoryPath`
 
-Path to the directory containing your attributes.
+Path to the directory containing your [attributes](/docs/attributes/).
 
 Defaults to `<rootDir>/attributes`.
 
 ### `segmentsDirectoryPath`
 
-Path to the directory containing your segments.
+Path to the directory containing your [segments](/docs/segments/).
 
 Defaults to `<rootDir>/segments`.
 
 ### `featuresDirectoryPath`
 
-Path to the directory containing your features.
+Path to the directory containing your [features](/docs/features/).
 
 Defaults to `<rootDir>/features`.
 
 ### `groupsDirectoryPath`
 
-Path to the directory containing your groups.
+Path to the directory containing your [groups](/docs/groups/).
 
 Defaults to `<rootDir>/groups`.
 
 ### `testsDirectoryPath`
 
-Path to the directory containing your tests.
+Path to the directory containing your [tests](/docs/testing/).
 
 Defaults to `<rootDir>/tests`.
+
+### `outputDirectoryPath`
+
+Path to the directory for your generated [datafiles](/docs/building-datafiles/).
+
+Defaults to `<rootDir>/dist`.
 
 ### `stateDirectoryPath`
 

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -16,6 +16,7 @@ export interface BuildCLIOptions {
   pretty?: boolean;
   stateFiles?: boolean; // --no-state-files in CLI
   inflate?: number;
+  datafilesDir?: string;
 }
 
 export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptions = {}) {
@@ -87,6 +88,7 @@ export async function buildProject(deps: Dependencies, cliOptions: BuildCLIOptio
       await datasource.writeDatafile(datafileContent, {
         environment,
         tag,
+        datafilesDir: cliOptions.datafilesDir,
       });
     }
 

--- a/packages/core/src/datasource/adapter.ts
+++ b/packages/core/src/datasource/adapter.ts
@@ -11,6 +11,7 @@ import {
 export interface DatafileOptions {
   environment: EnvironmentKey;
   tag: string;
+  datafilesDir?: string;
 }
 
 export abstract class Adapter {

--- a/packages/core/src/datasource/filesystemAdapter.ts
+++ b/packages/core/src/datasource/filesystemAdapter.ts
@@ -183,8 +183,9 @@ export class FilesystemAdapter extends Adapter {
    */
   getDatafilePath(options: DatafileOptions): string {
     const fileName = `datafile-tag-${options.tag}.json`;
+    const dir = options.datafilesDir || this.config.outputDirectoryPath;
 
-    return path.join(this.config.outputDirectoryPath, options.environment, fileName);
+    return path.join(dir, options.environment, fileName);
   }
 
   async readDatafile(options: DatafileOptions): Promise<DatafileContent> {
@@ -196,10 +197,9 @@ export class FilesystemAdapter extends Adapter {
   }
 
   async writeDatafile(datafileContent: DatafileContent, options: DatafileOptions): Promise<void> {
-    const outputEnvironmentDirPath = path.join(
-      this.config.outputDirectoryPath,
-      options.environment,
-    );
+    const dir = options.datafilesDir || this.config.outputDirectoryPath;
+
+    const outputEnvironmentDirPath = path.join(dir, options.environment);
     mkdirp.sync(outputEnvironmentDirPath);
 
     const outputFilePath = this.getDatafilePath(options);
@@ -211,7 +211,7 @@ export class FilesystemAdapter extends Adapter {
         : JSON.stringify(datafileContent),
     );
 
-    const root = path.resolve(this.config.outputDirectoryPath, "..");
+    const root = path.resolve(dir, "..");
 
     const shortPath = outputFilePath.replace(root + path.sep, "");
     console.log(`     Datafile generated: ${shortPath}`);


### PR DESCRIPTION
## What's done

A new option introduced in CLI, that allows overriding the project configuration for the directory path where new generated datafiles will be written under:

```
$ npx featurevisor build --datafiles-dir=./custom-datafiles-dir
```

Be default it will still write datafiles to `dist` directory, which is configurable via the `outputDirectoryPath` option in `featurevisor.config.js` file: https://featurevisor.com/docs/configuration/