### PR TITLE
fix: convert to datafile schema v2 internally

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@featurevisor/core": "^1.29.0"
+    "@featurevisor/core": "1.29.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,9 +40,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@featurevisor/sdk": "^1.28.0",
-    "@featurevisor/site": "^1.28.0",
-    "@featurevisor/types": "^1.28.0",
+    "@featurevisor/sdk": "1.28.0",
+    "@featurevisor/site": "1.28.0",
+    "@featurevisor/types": "1.28.0",
     "axios": "^1.3.4",
     "js-yaml": "^4.1.0",
     "mkdirp": "^2.1.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@featurevisor/types": "^1.28.0",
+    "@featurevisor/types": "1.28.0",
     "compare-versions": "^6.0.0-rc.1",
     "murmurhash": "^2.0.1"
   }

--- a/packages/sdk/src/datafileReader.spec.ts
+++ b/packages/sdk/src/datafileReader.spec.ts
@@ -1,4 +1,4 @@
-import { DatafileContent } from "@featurevisor/types";
+import { Attribute, DatafileContent } from "@featurevisor/types";
 import { DatafileReader } from "./datafileReader";
 
 describe("sdk: DatafileReader", function () {
@@ -6,7 +6,7 @@ describe("sdk: DatafileReader", function () {
     expect(typeof DatafileReader).toEqual("function");
   });
 
-  it("should return requested entities", function () {
+  it("v1 datafile schema: should return requested entities", function () {
     const datafileJson: DatafileContent = {
       schemaVersion: "1",
       revision: "1",
@@ -84,6 +84,92 @@ describe("sdk: DatafileReader", function () {
     expect((reader.getSegment("germany") as any).conditions[0].value).toEqual("de");
     expect(reader.getSegment("belgium")).toEqual(undefined);
     expect(reader.getFeature("test")).toEqual(datafileJson.features[0]);
+    expect(reader.getFeature("test2")).toEqual(undefined);
+  });
+
+  it("v2 datafile schema: should return requested entities", function () {
+    const datafileJson: DatafileContent = {
+      schemaVersion: "2",
+      revision: "1",
+      attributes: {
+        userId: {
+          key: "userId",
+          type: "string",
+          capture: true,
+        },
+        country: {
+          key: "country",
+          type: "string",
+        },
+      },
+      segments: {
+        netherlands: {
+          key: "netherlands",
+          conditions: [
+            {
+              attribute: "country",
+              operator: "equals",
+              value: "nl",
+            },
+          ],
+        },
+        germany: {
+          key: "germany",
+          conditions: JSON.stringify([
+            {
+              attribute: "country",
+              operator: "equals",
+              value: "de",
+            },
+          ]),
+        },
+      },
+      features: {
+        test: {
+          key: "test",
+          bucketBy: "userId",
+          variations: [
+            { value: "control" },
+            {
+              value: "treatment",
+              variables: [
+                {
+                  key: "showSidebar",
+                  value: true,
+                },
+              ],
+            },
+          ],
+          traffic: [
+            {
+              key: "1",
+              segments: "*",
+              percentage: 100000,
+              allocation: [
+                { variation: "control", range: [0, 0] },
+                { variation: "treatment", range: [0, 100000] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const reader = new DatafileReader(datafileJson);
+
+    expect(reader.getRevision()).toEqual("1");
+    expect(reader.getSchemaVersion()).toEqual("2");
+    expect(reader.getAllAttributes()).toEqual(
+      Object.keys(datafileJson.attributes).reduce((acc, key) => {
+        acc.push(datafileJson.attributes[key]);
+        return acc;
+      }, [] as Attribute[]),
+    );
+    expect(reader.getAttribute("userId")).toEqual(datafileJson.attributes.userId);
+    expect(reader.getSegment("netherlands")).toEqual(datafileJson.segments.netherlands);
+    expect((reader.getSegment("germany") as any).conditions[0].value).toEqual("de");
+    expect(reader.getSegment("belgium")).toEqual(undefined);
+    expect(reader.getFeature("test")).toEqual(datafileJson.features.test);
     expect(reader.getFeature("test2")).toEqual(undefined);
   });
 });


### PR DESCRIPTION
## Background

- SDK evaluations were made faster recently with a new v2 datafile schema: https://github.com/featurevisor/featurevisor/pull/334
- It still required users to build datafiles with `$ npx featurevisor build --schema-version=2`

## What's done

Even if fetched datafile is of schema v1, SDK will now internally convert it to v2 equivalent data structure in the runtime so it can benefit from O(1) level lookups instead of O(n).

Every time the datafile content it set to the SDK, it will do the conversion once. And for any subsequent evaluations, it will benefit from faster lookups.

## How to update?

Just upgrade to latest `@featurevisor/sdk` package, nothing else is needed to be done by consumers.