### PR TITLE
chore: publish packages with exact versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor}}@users.noreply.github.com"
-          npx lerna version --conventional-commits --conventional-graduate --yes
+          npx lerna version --conventional-commits --conventional-graduate --exact --yes
 
       - name: Bump version fallback
         if: ${{ always() && steps.graduateRelease.outcome == 'failure'  }}
@@ -55,7 +55,7 @@ jobs:
 
           echo "Falling back to non-graduate release due to https://github.com/lerna/lerna/issues/2532"
           git stash
-          npx lerna version --conventional-commits --yes
+          npx lerna version --conventional-commits --exact --yes
 
       - name: Publish
         run: |

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,6 +1,6 @@
 # @featurevisor/types
 
-> Common TypeScript typings for Featurevisor packages.
+> Common TypeScript typings for Featurevisor packages
 
 Visit [https://featurevisor.com](https://featurevisor.com) for more information.
 


### PR DESCRIPTION
## What's done

Published packages will have dependencies marked with exact versions, without any punctuations like `^` in the beginning of the dependency version numbers.

## Why

This will make it easier to downgrade to lower versions in case people have issues with more recent versions.