### PR TITLE
feat: Adds validation for duplicate segments and attributes

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -17,6 +17,103 @@ And it will show you the errors in your definition files, if any.
 
 If any errors are found, it will terminate with a non-zero exit code.
 
+## Validation Rules
+
+### Feature Rules
+
+The linter prevents duplicate segments within feature rules to avoid redundant targeting:
+
+```yml
+# Invalid: Duplicate segment in rule
+environments:
+  production:
+    rules:
+      - key: "1"
+        segments:
+          - foo
+          - bar
+          - foo  # Error: Duplicate segment
+        percentage: 100
+
+# Invalid: Duplicate segment in force rule
+environments:
+  production:
+    force:
+      - segments:
+          - foo
+          - bar
+          - foo  # Error: Duplicate segment
+```
+
+### Segment Conditions
+
+The linter enforces several rules for segment conditions to prevent redundant or conflicting conditions. These rules help maintain clean and logical segment definitions while still allowing flexibility for valid business cases.
+
+1. **AND Conditions**:
+   - Cannot have the same attribute with the same operator multiple times (prevents redundant conditions)
+   - Valid: Using same attribute with different operators (e.g., for range checks)
+   ```yml
+   # Invalid: Same attribute + operator (redundant)
+   and:
+     - attribute: country
+       operator: equals
+       value: "US"
+     - attribute: country
+       operator: equals
+       value: "CA"
+
+   # Valid: Same attribute, different operators (range check)
+   and:
+     - attribute: age
+       operator: greaterThan
+       value: 18
+     - attribute: age
+       operator: lessThan
+       value: 65
+   ```
+
+2. **OR Conditions**:
+   - Allows duplicate attributes and operators
+   - Useful for handling multiple valid values or different data formats
+   - Common use case: Supporting both string and number formats for version checks
+   ```yml
+   # Valid: Multiple formats for same attribute
+   or:
+     - attribute: version
+       operator: equals
+       value: 5.5      # number format
+     - attribute: version
+       operator: equals
+       value: "5.5"    # string format
+   ```
+
+3. **NOT Conditions**:
+   - Cannot have duplicate attributes at all
+   - This prevents redundant or potentially conflicting negations
+   - Use OR/AND conditions instead for multiple exclusions
+   ```yml
+   # Invalid: Same attribute used multiple times in NOT
+   not:
+     - attribute: device
+       operator: equals
+       value: "mobile"
+     - attribute: device
+       operator: equals
+       value: "tablet"
+
+   # Better approach: Use OR condition
+   not:
+     - or:
+         - attribute: device
+           operator: equals
+           value: "mobile"
+         - attribute: device
+           operator: equals
+           value: "tablet"
+   ```
+
+These validation rules are enforced during the linting process to help catch potential issues early in your development workflow.
+
 ## CLI options
 
 ### `keyPattern`


### PR DESCRIPTION
closes [#228 ](https://github.com/featurevisor/featurevisor/issues/228)

## What's Done
1. Added validation to prevent duplicate segments in feature rules:
   - Checks for duplicate segments within a single rule's segments array
   - Checks for duplicate segments within force rules
   - Provides clear error messages identifying which rule contains duplicates

2. Added validation for segment conditions to prevent redundant or conflicting conditions:
   - AND conditions: Prevents same attribute-operator pairs (e.g., duplicate country-equals checks)
   - OR conditions: Allows duplicates to support multiple formats/values
   - NOT conditions: Prevents duplicate attributes to avoid conflicting negations

3. Added comprehensive documentation in `docs/linting.md`:
   - Feature rules validation with examples
   - Segment conditions validation with examples for each type (AND/OR/NOT)
   - Clear explanations of what's allowed and what's not
   - Examples of valid alternatives for common cases

## Benefits
- Prevents redundant targeting in feature rules
- Catches logical errors in segment conditions early
- Improves maintainability by enforcing clean definitions
- Provides clear guidance through validation messages