### PR TITLE
fix: matched rules with percentage of 0 should be disabled

### DIFF
--- a/examples/example-1/features/showNotification.yml
+++ b/examples/example-1/features/showNotification.yml
@@ -1,0 +1,17 @@
+description: Classic on/off switch
+tags:
+  - all
+
+bucketBy: userId
+
+environments:
+  staging:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 100
+  production:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 0

--- a/examples/example-1/tests/showNotification.spec.yml
+++ b/examples/example-1/tests/showNotification.spec.yml
@@ -1,0 +1,19 @@
+feature: showNotification
+assertions:
+  - matrix:
+      at: [0, 50, 100]
+    at: ${{ at }}
+    description: "At ${{ at }}% in staging, the feature should be enabled"
+    environment: staging
+    context:
+      country: nl
+    expectedToBeEnabled: true
+
+  - matrix:
+      at: [0, 50, 100]
+    at: ${{ at }}
+    description: "At ${{ at }}% in production, the feature should be disabled"
+    environment: production
+    context:
+      country: nl
+    expectedToBeEnabled: false

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -33,7 +33,7 @@ export function getMatchedTraffic(
   datafileReader: DatafileReader,
   logger: Logger,
 ): Traffic | undefined {
-  return traffic.find((t) => {
+  const matchedTraffic = traffic.find((t) => {
     if (
       !allGroupSegmentsAreMatched(
         parseFromStringifiedSegments(t.segments),
@@ -47,6 +47,12 @@ export function getMatchedTraffic(
 
     return true;
   });
+
+  if (matchedTraffic && matchedTraffic.percentage > 0) {
+    return matchedTraffic;
+  }
+
+  return;
 }
 
 export interface MatchedTrafficAndAllocation {


### PR DESCRIPTION
## Issue

When the feature's matched rule has a percentage of `0`, it should be always disabled without making it go through bucketing process.

## Reproduction

See `example-1` project's `showNotification` feature (along with its test spec) introduced in the diff.

## Understanding bucketing

Every feature defines how they wish to be bucketed against users/devices (or any other attribute) via `bucketBy` property: https://featurevisor.com/docs/features/#bucketing

Learn more about bucketing logic here: https://featurevisor.com/docs/bucketing/

During evaluation, a bucket value is generated consistently for the same user/device against the same feature, which ranges between 0 and 100,000 (it's actually 0 and 100, but the integer value is multiplied by 1000 to account for 3 decimal places).

## Assessing distribution

Learn more about how to assess distribution via CLI here by simulating real user/device IDs: https://featurevisor.com/docs/cli/#assess-distribution

### Before

We have a `showNotification` feature in `example-1` project (introduced in this PR, see diff), which is:

- bucketed against `userId` attribute
- disabled for everyone in production

Below, we are assessing the distribution by evaluating the feature 1 million times, with a new randomly generated UUID as `userId` value in context per each evaluation:

```
$ npx featurevisor assess-distribution \
    --environment=production \
    --feature=showNotification \
    --context='{}' \
    --populateUuid=userId \
    -n=1000000

Evaluating 1,000,000 times...


Flag evaluations:

  - disabled: 	999,995 	100.00%
  - enabled:  	      5 	  0.00%
```

All 1 million evaluations should have been `disabled`, but we see some are leaking as `enabled`.

For me, the wrong evaluations have ranged between 5 and 13 out of 1 million evaluations.

Those are leaking because some of those randomly generated UUIDs resulted in a bucket value of `0`, which is a theoretical possibility of 1 out of 100,000.

I have run the above command repeatedly, and I haven't managed to see the number exceed more than 13 times per 1 million evaluations (think 1 million random UUIDs as device IDs).

Worst case scenario: 0.00001% users negatively affected (1 out of 100,000 for the bucketing range)

### After

With the fix introduced in this PR:

```
$ npx featurevisor assess-distribution \
    --environment=production \
    --feature=showNotification \
    --context='{}' \
    --populateUuid=userId \
    -n=1000000

Evaluating 1,000,000 times...

Flag evaluations:

  - disabled: 	1,000,000 	100.00%
  - enabled:  	        0 	  0.00%
```

We see that ALL the evaluations are correctly evaluating as disabled.