### PR TITLE
feat: allow setting max character limits for variables

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,3 +96,19 @@ By default, Featurevisor expects YAML for all definitions. You can change this t
 ### `enforceCatchAllRule`
 
 When set to `true`, linting will make sure all features have a catch-all rule with `segment: "*"` as the last rule in all environments.
+
+### `maxVariableStringLength`
+
+Maximum length of a string variable in features. Defaults to no limit.
+
+### `maxVariableArrayStringifiedLength`
+
+Maximum length of a stringified array variable in features. Defaults to no limit.
+
+### `maxVariableObjectStringifiedLength`
+
+Maximum length of a stringified object variable in features. Defaults to no limit.
+
+### `maxVariableJSONStringifiedLength`
+
+Maximum length of a JSON stringified variable in features. Defaults to no limit.

--- a/packages/core/src/config/projectConfig.ts
+++ b/packages/core/src/config/projectConfig.ts
@@ -37,17 +37,26 @@ export interface ProjectConfig {
   testsDirectoryPath: string;
   stateDirectoryPath: string;
   outputDirectoryPath: string;
+  siteExportDirectoryPath: string;
+
   environments: string[];
   tags: string[];
+
+  adapter: any; // @TODO: type this properly later
+  plugins: Plugin[];
+
   defaultBucketBy: BucketBy;
   parser: Parser;
+
   prettyState: boolean;
   prettyDatafile: boolean;
   stringify: boolean;
-  siteExportDirectoryPath: string;
+
   enforceCatchAllRule?: boolean;
-  adapter: any; // @TODO: type this properly later
-  plugins: Plugin[];
+  maxVariableStringLength?: number;
+  maxVariableArrayStringifiedLength?: number;
+  maxVariableObjectStringifiedLength?: number;
+  maxVariableJSONStringifiedLength?: number;
 }
 
 // rootDirectoryPath: path to the root directory of the project (without ending with a slash)
@@ -76,6 +85,11 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
 
     enforceCatchAllRule: false,
     plugins: [],
+
+    maxVariableStringLength: undefined,
+    maxVariableArrayStringifiedLength: undefined,
+    maxVariableObjectStringifiedLength: undefined,
+    maxVariableJSONStringifiedLength: undefined,
   };
 
   const configModulePath = path.join(rootDirectoryPath, CONFIG_MODULE_NAME);


### PR DESCRIPTION
## What's done

Introduced new (optional) configuration params in `featurevisor.config.js`:

```
// featurevisor.config.js
module.exports = {
  // ...

  // new configs
  maxVariableStringLength: 28,
  maxVariableArrayStringifiedLength: 41,
  maxVariableObjectStringifiedLength: 124,
  maxVariableJSONStringifiedLength: 16,
};
```

## How to use

If they are available as configs, linting will pick up issues if any:

```
$ npx featurevisor lint
```