### PR TITLE
feat: variables schema as dictionary

### DIFF
--- a/examples/example-1/features/sidebar.yml
+++ b/examples/example-1/features/sidebar.yml
@@ -18,6 +18,24 @@ variablesSchema:
   - key: title
     type: string
     defaultValue: "Sidebar Title"
+  - key: title2
+    type: string
+    defaultValue: "Sidebar Title 2"
+  - key: title3
+    type: string
+    defaultValue: "Sidebar Title 3"
+  - key: title4
+    type: string
+    defaultValue: "Sidebar Title 4"
+  - key: title5
+    type: string
+    defaultValue: "Sidebar Title 5"
+  - key: title6
+    type: string
+    defaultValue: "Sidebar Title 6"
+  - key: title7
+    type: string
+    defaultValue: "Sidebar Title 7"
 
 variations:
   - value: control

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -395,6 +395,14 @@ export async function buildDatafile(
     }, {});
 
     datafileContentV2.features = features.reduce((acc, feature) => {
+      if (Array.isArray(feature.variablesSchema)) {
+        feature.variablesSchema = feature.variablesSchema.reduce((vAcc, variableSchema) => {
+          vAcc[variableSchema.key] = variableSchema;
+
+          return vAcc;
+        }, {});
+      }
+
       acc[feature.key] = feature;
       return acc;
     }, {});

--- a/packages/core/src/evaluate/index.ts
+++ b/packages/core/src/evaluate/index.ts
@@ -110,17 +110,21 @@ export async function evaluateFeature(deps: Dependencies, options: EvaluateOptio
 
   const feature = f.getFeature(options.feature);
   if (feature?.variablesSchema) {
-    feature.variablesSchema.forEach((v) => {
+    const variableKeys = Array.isArray(feature.variablesSchema)
+      ? feature.variablesSchema
+      : Object.keys(feature.variablesSchema);
+
+    variableKeys.forEach((variableKey) => {
       const variableEvaluation = f.evaluateVariable(
         options.feature,
-        v.key,
+        variableKey,
         options.context as Context,
       );
 
-      variableEvaluationLogs[v.key] = [...logs];
+      variableEvaluationLogs[variableKey] = [...logs];
       logs = [];
 
-      variableEvaluations[v.key] = variableEvaluation;
+      variableEvaluations[variableKey] = variableEvaluation;
     });
   }
 

--- a/packages/sdk/src/datafileReader.ts
+++ b/packages/sdk/src/datafileReader.ts
@@ -56,6 +56,13 @@ export class DatafileReader {
 
       this.features = {};
       datafileJsonV1.features.forEach((f) => {
+        if (Array.isArray(f.variablesSchema)) {
+          f.variablesSchema = f.variablesSchema.reduce((acc, variable) => {
+            acc[variable.key] = variable;
+            return acc;
+          }, {});
+        }
+
         this.features[f.key] = f;
       });
     }

--- a/packages/sdk/src/evaluate.ts
+++ b/packages/sdk/src/evaluate.ts
@@ -292,9 +292,9 @@ export function evaluate(options: EvaluateOptions): Evaluation {
     let variableSchema: VariableSchema | undefined;
 
     if (variableKey) {
-      variableSchema = Array.isArray(feature.variablesSchema)
-        ? feature.variablesSchema.find((v) => v.key === variableKey)
-        : undefined;
+      if (feature.variablesSchema && feature.variablesSchema[variableKey]) {
+        variableSchema = feature.variablesSchema[variableKey];
+      }
 
       // variable schema not found
       if (!variableSchema) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -241,7 +241,7 @@ export interface Feature {
   key: FeatureKey;
   deprecated?: boolean;
   required?: Required[];
-  variablesSchema?: VariableSchema[];
+  variablesSchema?: VariableSchema[] | Record<VariableKey, VariableSchema>;
   variations?: Variation[];
   bucketBy: BucketBy;
   traffic: Traffic[];


### PR DESCRIPTION
## Background

Feature definitions have `variablesSchema` which is an array: https://featurevisor.com/docs/features/#variables

When evaluating variables, this schema is looked up by the SDK, which results into an O(n) lookup.

## What's done

Without breaking the API, those who wish to benefit from v2 datafile schema, can build their datafiles doing:

```
$ npx featurevisor build --schema-version=2
```

As well as for testing for improved confidence:

```
$ npx featurevisor test --schema-version=2
```

And the generated datafile will contain `variablesSchema` of the features as a dictionary (object) resulting into O(1) lookups.

Irrespective of generating datafiles in v2 format, the SDK will still optimize the data structure of v1 datafiles when parsing datafile internally resulting into O(1) lookups.

## Why?

Because of faster lookups, variable evaluations will be faster now. Especially if you have a lot of variables under a single feature.

## No breaking changes

You can still continue to write `variablesSchema` in your feature definition files as an array. Nothing changes there, and all this optimization is being handled internally.

Ideally when v2.0 lands after #326, it will become a breaking change.

## Benchmarks

This was done by updating example-1 project's `sidebar` feature so it has 10 variables.

Then this command was run before and after this optimization, evaluating the last variable 1 million times to get average evaluation duration:

```
$ npx featurevisor benchmark --environment=production --feature=sidebar --variable=title7 --context='{"country": "nl"}' -n=1000000
```

- Before: ~0.00061ms
- After: ~0.00056ms

Around 8% faster.

This may seem small against very simple variables. But as your variables grow, the performance gain will be much higher.