### PR TITLE
feat: allow deprecating variables

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -649,7 +649,19 @@ deprecated: true
 
 Deprecating a feature will still include the feature in generated datafiles and SDKs will still be able to evaluate the feature, but evaluation will lead to showing a warning in the logs.
 
-This is done to help notify the developers to stop using the affected feature without breaking the application.
+Similarly, variables can also be deprecated:
+
+```yml
+# ...
+
+variablesSchema:
+  - key: bgColor
+    type: string
+    defaultValue: red
+    deprecated: true # mark as deprecated
+```
+
+This is done to help notify the developers to stop using the affected feature or its variable without breaking the application.
 
 ## Archiving
 

--- a/examples/example-1/features/newRedesign.yml
+++ b/examples/example-1/features/newRedesign.yml
@@ -11,6 +11,7 @@ variablesSchema:
   - key: bar
     type: string
     defaultValue: "default bar"
+    deprecated: true
 
 variations:
   - value: control

--- a/packages/core/json-schema/feature.json
+++ b/packages/core/json-schema/feature.json
@@ -69,6 +69,10 @@
           "items": {
             "type": "object",
             "properties": {
+              "deprecated": {
+                "type": "boolean",
+                "description": "Indicates whether the variable is deprecated or not."
+              },
               "key": {
                 "type": "string",
                 "description": "Key of the variable."

--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -266,6 +266,7 @@ export async function buildDatafile(
             key: v.key,
             type: v.type,
             defaultValue: v.defaultValue,
+            deprecated: v.deprecated === true ? true : undefined,
           };
         });
       }

--- a/packages/core/src/linter/featureSchema.ts
+++ b/packages/core/src/linter/featureSchema.ts
@@ -382,10 +382,12 @@ export function getFeatureZodSchema(
           })
           .strict(),
       ]),
+      // @TODO: in v2, this will become a dictionary
       variablesSchema: z
         .array(
           z
             .object({
+              deprecated: z.boolean().optional(),
               key: z
                 .string()
                 .min(1)

--- a/packages/sdk/src/evaluate.ts
+++ b/packages/sdk/src/evaluate.ts
@@ -308,6 +308,13 @@ export function evaluate(options: EvaluateOptions): Evaluation {
 
         return evaluation;
       }
+
+      if (variableSchema.deprecated) {
+        logger.warn("variable is deprecated", {
+          featureKey: feature.key,
+          variableKey,
+        });
+      }
     }
 
     // variation: no variations

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -163,6 +163,7 @@ export interface Variation {
 }
 
 export interface VariableSchema {
+  deprecated?: boolean;
   key: VariableKey;
   type: VariableType;
   defaultValue: VariableValue;


### PR DESCRIPTION
## What's done

We could always deprecate features before, so that warnings would appear when SDK would evaluate the feature:

```yml
# features/myFeature.yml

deprecated: true

# ...
```

Now, we can also deprecate variables inside a feature to emit similar warnings:

```yml
# features/myFeature.yml

variablesSchema:
  - key: foo
    type: string
    defaultValue: hello world
    deprecated: true # new property here

# ...
```