### PR TITLE
fix: namespaces in generated site

### DIFF
--- a/packages/site/src/components/HistoryTimeline.tsx
+++ b/packages/site/src/components/HistoryTimeline.tsx
@@ -24,7 +24,7 @@ function Activity(props) {
         <>
           {entry.entities[0].type}{" "}
           <Link
-            to={`/${entry.entities[0].type}s/${entry.entities[0].key}`}
+            to={`/${entry.entities[0].type}s/${encodeURIComponent(entry.entities[0].key)}`}
             className="font-semibold text-gray-600"
           >
             {entry.entities[0].key}
@@ -50,7 +50,7 @@ function Activity(props) {
                 <li key={index}>
                   <span className="text-gray-400">{entity.type}</span>{" "}
                   <Link
-                    to={`/${entity.type}s/${entity.key}`}
+                    to={`/${entity.type}s/${encodeURIComponent(entity.key)}`}
                     className="font-semibold text-gray-500"
                   >
                     {entity.key}

--- a/packages/site/src/components/ListAttributes.tsx
+++ b/packages/site/src/components/ListAttributes.tsx
@@ -25,7 +25,10 @@ export function ListAttributes() {
           <ul className="diving-gray-200 divide-y">
             {attributes.map((attribute: any) => (
               <li key={attribute.key}>
-                <Link to={`/attributes/${attribute.key}`} className="block hover:bg-gray-50">
+                <Link
+                  to={`/attributes/${encodeURIComponent(attribute.key)}`}
+                  className="block hover:bg-gray-50"
+                >
                   <div className="px-6 py-4">
                     <div className="flex items-center justify-between">
                       <p className="text-md relative font-bold text-slate-600">

--- a/packages/site/src/components/ListFeatures.tsx
+++ b/packages/site/src/components/ListFeatures.tsx
@@ -28,7 +28,7 @@ export function ListFeatures() {
           <ul className="diving-gray-200 divide-y">
             {features.map((feature: any) => (
               <li key={feature.key}>
-                <Link to={`/features/${feature.key}`}>
+                <Link to={`/features/${encodeURIComponent(feature.key)}`}>
                   <div className="block hover:bg-gray-50">
                     <div className="px-6 py-4">
                       <div className="flex items-center justify-between">

--- a/packages/site/src/components/ListSegments.tsx
+++ b/packages/site/src/components/ListSegments.tsx
@@ -25,7 +25,10 @@ export function ListSegments() {
           <ul className="diving-gray-200 divide-y">
             {segments.map((segment: any) => (
               <li key={segment.key}>
-                <Link to={`/segments/${segment.key}`} className="block hover:bg-gray-50">
+                <Link
+                  to={`/segments/${encodeURIComponent(segment.key)}`}
+                  className="block hover:bg-gray-50"
+                >
                   <div className="px-6 py-4">
                     <div className="flex items-center justify-between">
                       <p className="text-md relative font-bold text-slate-600">

--- a/packages/site/src/components/ShowAttribute.tsx
+++ b/packages/site/src/components/ShowAttribute.tsx
@@ -84,7 +84,7 @@ export function DisplayAttributeUsage() {
                 {attribute.usedInFeatures.map((feature) => {
                   return (
                     <li key={feature}>
-                      <Link to={`/features/${feature}`}>{feature}</Link>
+                      <Link to={`/features/${encodeURIComponent(feature)}`}>{feature}</Link>
                     </li>
                   );
                 })}
@@ -116,15 +116,15 @@ export function ShowAttribute() {
   const tabs = [
     {
       title: "Overview",
-      to: `/attributes/${attributeKey}`,
+      to: `/attributes/${encodeURIComponent(attributeKey)}`,
     },
     {
       title: "Usage",
-      to: `/attributes/${attributeKey}/usage`,
+      to: `/attributes/${encodeURIComponent(attributeKey)}/usage`,
     },
     {
       title: "History",
-      to: `/attributes/${attributeKey}/history`,
+      to: `/attributes/${encodeURIComponent(attributeKey)}/history`,
     },
   ];
 

--- a/packages/site/src/components/ShowFeature.tsx
+++ b/packages/site/src/components/ShowFeature.tsx
@@ -490,28 +490,28 @@ export function ShowFeature() {
   const tabs = [
     {
       title: "Overview",
-      to: `/features/${featureKey}`,
+      to: `/features/${encodeURIComponent(featureKey)}`,
       end: true,
     },
     {
       title: "Variations",
-      to: `/features/${featureKey}/variations`,
+      to: `/features/${encodeURIComponent(featureKey)}/variations`,
     },
     {
       title: "Variables",
-      to: `/features/${featureKey}/variables`,
+      to: `/features/${encodeURIComponent(featureKey)}/variables`,
     },
     {
       title: "Rules",
-      to: `/features/${featureKey}/rules`,
+      to: `/features/${encodeURIComponent(featureKey)}/rules`,
     },
     {
       title: "Force",
-      to: `/features/${featureKey}/force`,
+      to: `/features/${encodeURIComponent(featureKey)}/force`,
     },
     {
       title: "History",
-      to: `/features/${featureKey}/history`,
+      to: `/features/${encodeURIComponent(featureKey)}/history`,
     },
   ];
 

--- a/packages/site/src/components/ShowSegment.tsx
+++ b/packages/site/src/components/ShowSegment.tsx
@@ -64,7 +64,7 @@ export function DisplaySegmentUsage() {
                 {segment.usedInFeatures.map((feature) => {
                   return (
                     <li key={feature}>
-                      <Link to={`/features/${feature}`}>{feature}</Link>
+                      <Link to={`/features/${encodeURIComponent(feature)}`}>{feature}</Link>
                     </li>
                   );
                 })}
@@ -96,15 +96,15 @@ export function ShowSegment() {
   const tabs = [
     {
       title: "Overview",
-      to: `/segments/${segmentKey}`,
+      to: `/segments/${encodeURIComponent(segmentKey)}`,
     },
     {
       title: "Usage",
-      to: `/segments/${segmentKey}/usage`,
+      to: `/segments/${encodeURIComponent(segmentKey)}/usage`,
     },
     {
       title: "History",
-      to: `/segments/${segmentKey}/history`,
+      to: `/segments/${encodeURIComponent(segmentKey)}/history`,
     },
   ];
 


### PR DESCRIPTION
## What's done

Encode entity key names in URLs, to avoid issues with namespaced keys.

Refs https://github.com/featurevisor/featurevisor/pull/346