### PR TITLE
feat: list entities from CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -267,22 +267,24 @@ $ npx featurevisor list --features
 
 Advanced search options:
 
-| Option                         | Description                                        |
-| ------------------------------ | -------------------------------------------------- |
-| `--archived=<true or false>`   | by [archived](/docs/features/#archiving) status    |
-| `--description=<pattern>`      | by description pattern                             |
-| `--in=<environment>`           | enabled in an [environment](/docs/environments)    |
-| `--json`                       | print as JSON                                      |
-| `--keyPattern=<pattern>`       | by key pattern                                     |
-| `--tag=<tag>`                  | by [tag](/docs/tags/)                              |
-| `--variable=<variableKey>`     | containing specific variable key                   |
-| `--variation=<variationValue>` | containing specific variation key                  |
-| `--with-tests`                 | with [test specs](/docs/testing)                   |
-| `--with-variables`             | with variables                                     |
-| `--with-variations`            | with [variations](/docs/features/#variations)      |
-| `--without-tests`              | without any test specs                             |
-| `--without-variables`          | without any [variables](/docs/features/#variables) |
-| `--without-variations`         | without any variations                             |
+| Option                             | Description                                        |
+| ---------------------------------- | -------------------------------------------------- |
+| `--archived=<true or false>`       | by [archived](/docs/features/#archiving) status    |
+| `--description=<pattern>`          | by description pattern                             |
+| `--in=<environment>`               | enabled in an [environment](/docs/environments)    |
+| `--json`                           | print as JSON                                      |
+| `--keyPattern=<pattern>`           | by key pattern                                     |
+| `--tag=<tag>`                      | by [tag](/docs/tags/)                              |
+| `--variable=<variableKey>`         | containing specific variable key                   |
+| `--variableDescription=<pattern>`  | by variable description pattern                    |
+| `--variation=<variationValue>`     | containing specific variation key                  |
+| `--variationDescription=<pattern>` | by variation description pattern                   |
+| `--with-tests`                     | with [test specs](/docs/testing)                   |
+| `--with-variables`                 | with variables                                     |
+| `--with-variations`                | with [variations](/docs/features/#variations)      |
+| `--without-tests`                  | without any test specs                             |
+| `--without-variables`              | without any [variables](/docs/features/#variables) |
+| `--without-variations`             | without any variations                             |
 
 ### List segments
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -275,7 +275,6 @@ Advanced search options:
 | `--enabledIn=<environment>`        | enabled in an [environment](/docs/environments)        |
 | `--json`                           | print as JSON                                          |
 | `--keyPattern=<pattern>`           | by key pattern                                         |
-| `--notIn=<environment>`            | fully disabled in an [environment](/docs/environments) |
 | `--tag=<tag>`                      | by [tag](/docs/tags/)                                  |
 | `--variable=<variableKey>`         | containing specific variable key                       |
 | `--variableDescription=<pattern>`  | by variable description pattern                        |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,7 +97,6 @@ $ npx featurevisor site serve -p 3000
 
 Learn more in [Status site](/docs/status-site).
 
-
 ## Generate code
 
 Generate TypeScript code from your YAMLs:
@@ -256,6 +255,68 @@ $ npx featurevisor evaluate \
 
 You can optionally pass `--schema-version=2` if you are using the new schema v2.
 
+## List
+
+### List features
+
+To list all features in the project:
+
+```
+$ npx featurevisor list --features
+```
+
+Advanced search options:
+
+| Option                         | Description                                        |
+| ------------------------------ | -------------------------------------------------- |
+| `--archived=<true or false>`   | by [archived](/docs/features/#archiving) status    |
+| `--description=<pattern>`      | by description pattern                             |
+| `--in=<environment>`           | enabled in an [environment](/docs/environments)    |
+| `--keyPattern=<pattern>`       | by key pattern                                     |
+| `--tag=<tag>`                  | by [tag](/docs/tags/)                              |
+| `--variable=<variableKey>`     | containing specific variable key                   |
+| `--variation=<variationValue>` | containing specific variation key                  |
+| `--with-tests`                 | with [test specs](/docs/testing)                   |
+| `--with-variables`             | with variables                                     |
+| `--with-variations`            | with [variations](/docs/features/#variations)      |
+| `--without-tests`              | without any test specs                             |
+| `--without-variables`          | without any [variables](/docs/features/#variables) |
+| `--without-variations`         | without any variations                             |
+
+### List segments
+
+To list all segments in the project:
+
+```
+$ npx featurevisor list --segments
+```
+
+Advanced search options:
+
+| Option                       | Description                                     |
+| ---------------------------- | ----------------------------------------------- |
+| `--archived=<true or false>` | by [archived](/docs/segments/#archiving) status |
+| `--description=<pattern>`    | by description pattern                          |
+| `--keyPattern=<pattern>`     | by key pattern                                  |
+| `--with-tests`               | with [test specs](/docs/testing)                |
+| `--without-tests`            | without any test specs                          |
+
+### List attributes
+
+To list all attributes in the project:
+
+```
+$ npx featurevisor list --attributes
+```
+
+Advanced search options:
+
+| Option                       | Description                                       |
+| ---------------------------- | ------------------------------------------------- |
+| `--archived=<true or false>` | by [archived](/docs/attributes/#archiving) status |
+| `--description=<pattern>`    | by description pattern                            |
+| `--keyPattern=<pattern>`     | by key pattern                                    |
+
 ## Assess distribution
 
 To check if the gradual rollout of a feature and the weight distribution of its variations (if any exists) are going to work as expected in a real world application with real traffic against provided [context](/docs/sdks/javascript/#context), we can imitate that by running:
@@ -291,7 +352,6 @@ Shows count of various entities in the project:
 ```
 $ npx featurevisor info
 ```
-
 
 ## Version
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -271,7 +271,8 @@ Advanced search options:
 | ---------------------------------- | ------------------------------------------------------ |
 | `--archived=<true or false>`       | by [archived](/docs/features/#archiving) status        |
 | `--description=<pattern>`          | by description pattern                                 |
-| `--in=<environment>`               | enabled in an [environment](/docs/environments)        |
+| `--disabledIn=<environment>`       | disabled in an [environment](/docs/environments)       |
+| `--enabledIn=<environment>`        | enabled in an [environment](/docs/environments)        |
 | `--json`                           | print as JSON                                          |
 | `--keyPattern=<pattern>`           | by key pattern                                         |
 | `--notIn=<environment>`            | fully disabled in an [environment](/docs/environments) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -267,23 +267,23 @@ $ npx featurevisor list --features
 
 Advanced search options:
 
-| Option                             | Description                                            |
-| ---------------------------------- | ------------------------------------------------------ |
-| `--archived=<true or false>`       | by [archived](/docs/features/#archiving) status        |
-| `--description=<pattern>`          | by description pattern                                 |
-| `--disabledIn=<environment>`       | disabled in an [environment](/docs/environments)       |
-| `--enabledIn=<environment>`        | enabled in an [environment](/docs/environments)        |
-| `--json`                           | print as JSON                                          |
-| `--keyPattern=<pattern>`           | by key pattern                                         |
-| `--tag=<tag>`                      | by [tag](/docs/tags/)                                  |
-| `--variable=<variableKey>`         | containing specific variable key                       |
-| `--variation=<variationValue>`     | containing specific variation key                      |
-| `--with-tests`                     | with [test specs](/docs/testing)                       |
-| `--with-variables`                 | with variables                                         |
-| `--with-variations`                | with [variations](/docs/features/#variations)          |
-| `--without-tests`                  | without any test specs                                 |
-| `--without-variables`              | without any [variables](/docs/features/#variables)     |
-| `--without-variations`             | without any variations                                 |
+| Option                         | Description                                        |
+| ------------------------------ | -------------------------------------------------- |
+| `--archived=<true or false>`   | by [archived](/docs/features/#archiving) status    |
+| `--description=<pattern>`      | by description pattern                             |
+| `--disabledIn=<environment>`   | disabled in an [environment](/docs/environments)   |
+| `--enabledIn=<environment>`    | enabled in an [environment](/docs/environments)    |
+| `--json`                       | print as JSON                                      |
+| `--keyPattern=<pattern>`       | by key pattern                                     |
+| `--tag=<tag>`                  | by [tag](/docs/tags/)                              |
+| `--variable=<variableKey>`     | containing specific variable key                   |
+| `--variation=<variationValue>` | containing specific variation key                  |
+| `--with-tests`                 | with [test specs](/docs/testing)                   |
+| `--with-variables`             | with variables                                     |
+| `--with-variations`            | with [variations](/docs/features/#variations)      |
+| `--without-tests`              | without any test specs                             |
+| `--without-variables`          | without any [variables](/docs/features/#variables) |
+| `--without-variations`         | without any variations                             |
 
 ### List segments
 
@@ -301,6 +301,7 @@ Advanced search options:
 | `--description=<pattern>`    | by description pattern                          |
 | `--json`                     | print as JSON                                   |
 | `--keyPattern=<pattern>`     | by key pattern                                  |
+| `--pretty`                   | pretty JSON                                     |
 | `--with-tests`               | with [test specs](/docs/testing)                |
 | `--without-tests`            | without any test specs                          |
 
@@ -320,6 +321,25 @@ Advanced search options:
 | `--description=<pattern>`    | by description pattern                            |
 | `--json`                     | print as JSON                                     |
 | `--keyPattern=<pattern>`     | by key pattern                                    |
+| `--pretty`                   | pretty JSON                                       |
+
+### List tests
+
+To list all tests specs in the project:
+
+```
+$ npx featurevisor list --tests
+```
+
+Advanced search options:
+
+| Option                         | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| `--applyMatrix`                | apply matrix for assertions                       |
+| `--assertionPattern=<pattern>` | by assertion's description pattern                |
+| `--json`                       | print as JSON                                     |
+| `--keyPattern=<pattern>`       | by key pattern of feature or segment being tested |
+| `--pretty`                     | pretty JSON                                       |
 
 ## Assess distribution
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -272,6 +272,7 @@ Advanced search options:
 | `--archived=<true or false>`   | by [archived](/docs/features/#archiving) status    |
 | `--description=<pattern>`      | by description pattern                             |
 | `--in=<environment>`           | enabled in an [environment](/docs/environments)    |
+| `--json`                       | print as JSON                                      |
 | `--keyPattern=<pattern>`       | by key pattern                                     |
 | `--tag=<tag>`                  | by [tag](/docs/tags/)                              |
 | `--variable=<variableKey>`     | containing specific variable key                   |
@@ -297,6 +298,7 @@ Advanced search options:
 | ---------------------------- | ----------------------------------------------- |
 | `--archived=<true or false>` | by [archived](/docs/segments/#archiving) status |
 | `--description=<pattern>`    | by description pattern                          |
+| `--json`                     | print as JSON                                   |
 | `--keyPattern=<pattern>`     | by key pattern                                  |
 | `--with-tests`               | with [test specs](/docs/testing)                |
 | `--without-tests`            | without any test specs                          |
@@ -315,6 +317,7 @@ Advanced search options:
 | ---------------------------- | ------------------------------------------------- |
 | `--archived=<true or false>` | by [archived](/docs/attributes/#archiving) status |
 | `--description=<pattern>`    | by description pattern                            |
+| `--json`                     | print as JSON                                     |
 | `--keyPattern=<pattern>`     | by key pattern                                    |
 
 ## Assess distribution

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,9 +277,7 @@ Advanced search options:
 | `--keyPattern=<pattern>`           | by key pattern                                         |
 | `--tag=<tag>`                      | by [tag](/docs/tags/)                                  |
 | `--variable=<variableKey>`         | containing specific variable key                       |
-| `--variableDescription=<pattern>`  | by variable description pattern                        |
 | `--variation=<variationValue>`     | containing specific variation key                      |
-| `--variationDescription=<pattern>` | by variation description pattern                       |
 | `--with-tests`                     | with [test specs](/docs/testing)                       |
 | `--with-variables`                 | with variables                                         |
 | `--with-variations`                | with [variations](/docs/features/#variations)          |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -267,24 +267,25 @@ $ npx featurevisor list --features
 
 Advanced search options:
 
-| Option                             | Description                                        |
-| ---------------------------------- | -------------------------------------------------- |
-| `--archived=<true or false>`       | by [archived](/docs/features/#archiving) status    |
-| `--description=<pattern>`          | by description pattern                             |
-| `--in=<environment>`               | enabled in an [environment](/docs/environments)    |
-| `--json`                           | print as JSON                                      |
-| `--keyPattern=<pattern>`           | by key pattern                                     |
-| `--tag=<tag>`                      | by [tag](/docs/tags/)                              |
-| `--variable=<variableKey>`         | containing specific variable key                   |
-| `--variableDescription=<pattern>`  | by variable description pattern                    |
-| `--variation=<variationValue>`     | containing specific variation key                  |
-| `--variationDescription=<pattern>` | by variation description pattern                   |
-| `--with-tests`                     | with [test specs](/docs/testing)                   |
-| `--with-variables`                 | with variables                                     |
-| `--with-variations`                | with [variations](/docs/features/#variations)      |
-| `--without-tests`                  | without any test specs                             |
-| `--without-variables`              | without any [variables](/docs/features/#variables) |
-| `--without-variations`             | without any variations                             |
+| Option                             | Description                                            |
+| ---------------------------------- | ------------------------------------------------------ |
+| `--archived=<true or false>`       | by [archived](/docs/features/#archiving) status        |
+| `--description=<pattern>`          | by description pattern                                 |
+| `--in=<environment>`               | enabled in an [environment](/docs/environments)        |
+| `--json`                           | print as JSON                                          |
+| `--keyPattern=<pattern>`           | by key pattern                                         |
+| `--notIn=<environment>`            | fully disabled in an [environment](/docs/environments) |
+| `--tag=<tag>`                      | by [tag](/docs/tags/)                                  |
+| `--variable=<variableKey>`         | containing specific variable key                       |
+| `--variableDescription=<pattern>`  | by variable description pattern                        |
+| `--variation=<variationValue>`     | containing specific variation key                      |
+| `--variationDescription=<pattern>` | by variation description pattern                       |
+| `--with-tests`                     | with [test specs](/docs/testing)                       |
+| `--with-variables`                 | with variables                                         |
+| `--with-variations`                | with [variations](/docs/features/#variations)          |
+| `--without-tests`                  | without any test specs                                 |
+| `--without-variables`              | without any [variables](/docs/features/#variables)     |
+| `--without-variations`             | without any variations                                 |
 
 ### List segments
 

--- a/examples/example-1/features/foo.yml
+++ b/examples/example-1/features/foo.yml
@@ -17,6 +17,7 @@ variablesSchema:
   - key: qux
     type: boolean
     defaultValue: false
+    description: This is a boolean variable
 
 variations:
   - value: control

--- a/packages/core/src/cli/plugins.ts
+++ b/packages/core/src/cli/plugins.ts
@@ -13,6 +13,7 @@ import { configPlugin } from "../config";
 import { evaluatePlugin } from "../evaluate";
 import { assessDistributionPlugin } from "../assess-distribution";
 import { infoPlugin } from "../info";
+import { listPlugin } from "../list";
 import { sitePlugin } from "../site";
 
 // that do not require an existing project
@@ -32,6 +33,7 @@ export const projectBasedPlugins: Plugin[] = [
   evaluatePlugin,
   assessDistributionPlugin,
   infoPlugin,
+  listPlugin,
   sitePlugin,
 ];
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,4 +14,5 @@ export * from "./benchmark";
 export * from "./evaluate";
 export * from "./assess-distribution";
 export * from "./info";
+export * from "./list";
 export * from "./cli";

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -1,6 +1,6 @@
 import { Dependencies } from "../dependencies";
 import { Plugin } from "../cli";
-import { ParsedFeature, Segment, Attribute } from "@featurevisor/types";
+import { ParsedFeature, Segment, Attribute, VariableSchema } from "@featurevisor/types";
 
 async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
   const { datasource, options } = deps;
@@ -128,9 +128,25 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --variableDescription=<pattern>
-      // @TODO --variation=<variationValue>
-      // @TODO --variationDescription=<pattern>
+      // --variation=<variationValue>
+      if (options.variation) {
+        const lookForVariations = Array.isArray(options.variation)
+          ? options.variation
+          : [options.variation];
+
+        let variationsInFeature: string[] = parsedFeature.variations
+          ? parsedFeature.variations.map((v) => v.value)
+          : [];
+
+        const hasVariations = lookForVariations.every((variation) =>
+          variationsInFeature.includes(variation),
+        );
+
+        if (!hasVariations) {
+          continue;
+        }
+      }
+
       // @TODO --with-tests
       // @TODO --with-variables
       // @TODO --with-variations

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -198,7 +198,15 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --with-variables
+      // --with-variables
+      if (options.withVariables) {
+        const hasVariables = parsedFeature.variablesSchema;
+
+        if (!hasVariables) {
+          continue;
+        }
+      }
+
       // @TODO --with-variations
 
       // --without-tests
@@ -210,7 +218,15 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --without-variables
+      // --without-variables
+      if (options.withoutVariables) {
+        const hasVariables = parsedFeature.variablesSchema;
+
+        if (hasVariables) {
+          continue;
+        }
+      }
+
       // @TODO --without-variations
     } else if (entityType === "segment") {
       const segment = entity as Segment;

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -1,10 +1,52 @@
 import { Dependencies } from "../dependencies";
 import { Plugin } from "../cli";
+import { ParsedFeature } from "@featurevisor/types";
 
 export async function listProject(deps: Dependencies) {
-  const { rootDirectoryPath, projectConfig } = deps;
+  const { rootDirectoryPath, projectConfig, datasource, options } = deps;
 
-  console.log("Listing project...");
+  if (options.features) {
+    const allFeatureKeys = await datasource.listFeatures();
+
+    if (allFeatureKeys.length === 0) {
+      console.log("No features found.");
+      return;
+    }
+
+    const result: ParsedFeature[] = [];
+    for (const featureKey of allFeatureKeys) {
+      const feature = await datasource.readFeature(featureKey);
+
+      // @TODO: filter
+
+      result.push({
+        ...feature,
+        key: featureKey,
+      });
+    }
+
+    if (result.length === 0) {
+      console.log("No features found.");
+      return;
+    }
+
+    if (options.print) {
+      console.log(JSON.stringify(result));
+      return;
+    }
+
+    console.log("\nFeatures:\n");
+
+    for (const feature of result) {
+      console.log(`- ${feature.key}`);
+    }
+
+    console.log(`\n\nFound ${result.length} features.`);
+
+    return;
+  }
+
+  console.log("Nothing to list. Please pass `--features`, `--segments`, or `--attributes`.");
 }
 
 export const listPlugin: Plugin = {

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -2,49 +2,70 @@ import { Dependencies } from "../dependencies";
 import { Plugin } from "../cli";
 import { ParsedFeature } from "@featurevisor/types";
 
+async function listFeatures(deps: Dependencies) {
+  const { datasource, options } = deps;
+
+  const result: ParsedFeature[] = [];
+  const allFeatureKeys = await datasource.listFeatures();
+
+  if (allFeatureKeys.length === 0) {
+    return result;
+  }
+
+  for (const featureKey of allFeatureKeys) {
+    const feature = await datasource.readFeature(featureKey);
+
+    // @TODO: filter
+
+    result.push({
+      ...feature,
+      key: featureKey,
+    });
+  }
+
+  return result;
+}
+
+function ucfirst(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function printResult({ result, entityType, options }) {
+  if (options.json) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  if (result.length === 0) {
+    console.log(`No ${entityType}s found.`);
+    return;
+  }
+
+  console.log(`\n${ucfirst(entityType)}s:\n`);
+
+  for (const item of result) {
+    console.log(`- ${item.key}`);
+  }
+
+  console.log(`\n\nFound ${result.length} ${entityType}s.`);
+}
+
 export async function listProject(deps: Dependencies) {
   const { rootDirectoryPath, projectConfig, datasource, options } = deps;
 
+  // features
   if (options.features) {
-    const allFeatureKeys = await datasource.listFeatures();
+    const result = await listFeatures(deps);
 
-    if (allFeatureKeys.length === 0) {
-      console.log("No features found.");
-      return;
-    }
-
-    const result: ParsedFeature[] = [];
-    for (const featureKey of allFeatureKeys) {
-      const feature = await datasource.readFeature(featureKey);
-
-      // @TODO: filter
-
-      result.push({
-        ...feature,
-        key: featureKey,
-      });
-    }
-
-    if (result.length === 0) {
-      console.log("No features found.");
-      return;
-    }
-
-    if (options.print) {
-      console.log(JSON.stringify(result));
-      return;
-    }
-
-    console.log("\nFeatures:\n");
-
-    for (const feature of result) {
-      console.log(`- ${feature.key}`);
-    }
-
-    console.log(`\n\nFound ${result.length} features.`);
-
-    return;
+    return printResult({
+      result,
+      entityType: "feature",
+      options,
+    });
   }
+
+  // @TODO: segments
+  // @TODO: attributes
 
   console.log("Nothing to list. Please pass `--features`, `--segments`, or `--attributes`.");
 }

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -245,17 +245,79 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
     } else if (entityType === "segment") {
       const segment = entity as Segment;
 
-      // @TODO --archived=true|false
-      // @TODO --description=<pattern>
-      // @TODO --keyPattern=<pattern>
-      // @TODO --with-tests
-      // @TODO --without-tests
+      // --archived=true|false
+      if (segment.archived) {
+        const archivedStatus = options.archived === "false";
+
+        if (segment.archived !== archivedStatus) {
+          continue;
+        }
+      }
+
+      // --description=<pattern>
+      if (options.description) {
+        const description = segment.description || "";
+
+        const regex = new RegExp(options.description, "i");
+        if (!regex.test(description)) {
+          continue;
+        }
+      }
+
+      // --keyPattern=<pattern>
+      if (options.keyPattern) {
+        const regex = new RegExp(options.keyPattern, "i");
+        if (!regex.test(key)) {
+          continue;
+        }
+      }
+
+      // --with-tests
+      if (options.withTests) {
+        await initializeEntitiesWithTests();
+
+        if (!entitiesWithTests.segments.includes(key)) {
+          continue;
+        }
+      }
+
+      // --without-tests
+      if (options.withoutTests) {
+        await initializeEntitiesWithTests();
+
+        if (entitiesWithTests.segments.includes(key)) {
+          continue;
+        }
+      }
     } else if (entityType === "attribute") {
       const attribute = entity as Attribute;
 
-      // @TODO --archived=true|false
-      // @TODO --description=<pattern>
-      // @TODO --keyPattern=<pattern>
+      // --archived=true|false
+      if (options.archived) {
+        const archivedStatus = options.archived === "false";
+
+        if (attribute.archived !== archivedStatus) {
+          continue;
+        }
+      }
+
+      // --description=<pattern>
+      if (options.description) {
+        const description = attribute.description || "";
+
+        const regex = new RegExp(options.description, "i");
+        if (!regex.test(description)) {
+          continue;
+        }
+      }
+
+      // --keyPattern=<pattern>
+      if (options.keyPattern) {
+        const regex = new RegExp(options.keyPattern, "i");
+        if (!regex.test(key)) {
+          continue;
+        }
+      }
     }
 
     result.push({

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -54,34 +54,44 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // --in=<environment>
-      if (parsedFeature.environments && parsedFeature.environments[options.in]) {
-        const enabledInEnvironment = parsedFeature.environments[options.in].rules.some((rule) => {
-          return rule.percentage > 0;
-        });
-
-        if (!enabledInEnvironment) {
-          continue;
-        }
-      }
-
-      // @TODO --keyPattern=<pattern>
-      if (options.keyPattern) {
-        const regex = new RegExp(options.keyPattern, "i");
-        if (!regex.test(key)) {
-          continue;
-        }
-      }
-
-      // --notIn=<environment>
-      if (parsedFeature.environments && parsedFeature.environments[options.notIn]) {
-        const disabledInEnvironment = parsedFeature.environments[options.notIn].rules.every(
+      // --disabledIn=<environment>
+      if (
+        options.disabledIn &&
+        parsedFeature.environments &&
+        parsedFeature.environments[options.disabledIn]
+      ) {
+        const disabledInEnvironment = parsedFeature.environments[options.disabledIn].rules.every(
           (rule) => {
             return rule.percentage === 0;
           },
         );
 
         if (!disabledInEnvironment) {
+          continue;
+        }
+      }
+
+      // --enabledIn=<environment>
+      if (
+        options.enabledIn &&
+        parsedFeature.environments &&
+        parsedFeature.environments[options.enabledIn]
+      ) {
+        const enabledInEnvironment = parsedFeature.environments[options.enabledIn].rules.some(
+          (rule) => {
+            return rule.percentage > 0;
+          },
+        );
+
+        if (!enabledInEnvironment) {
+          continue;
+        }
+      }
+
+      // --keyPattern=<pattern>
+      if (options.keyPattern) {
+        const regex = new RegExp(options.keyPattern, "i");
+        if (!regex.test(key)) {
           continue;
         }
       }
@@ -96,7 +106,16 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --variable=<variableKey>
+      // --variable=<variableKey>
+      if (options.variable) {
+        const variables = Array.isArray(options.variable) ? options.variable : [options.variable];
+        const hasVariables = variables.every((variable) => parsedFeature.tags.includes(variable));
+
+        if (!hasVariables) {
+          continue;
+        }
+      }
+
       // @TODO --variableDescription=<pattern>
       // @TODO --variation=<variationValue>
       // @TODO --variationDescription=<pattern>

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -108,8 +108,20 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
 
       // --variable=<variableKey>
       if (options.variable) {
-        const variables = Array.isArray(options.variable) ? options.variable : [options.variable];
-        const hasVariables = variables.every((variable) => parsedFeature.tags.includes(variable));
+        const lookForVariables = Array.isArray(options.variable)
+          ? options.variable
+          : [options.variable];
+
+        let variablesInFeature: string[] = [];
+        if (Array.isArray(parsedFeature.variablesSchema)) {
+          variablesInFeature = parsedFeature.variablesSchema.map((variable) => variable.key);
+        } else if (parsedFeature.variablesSchema) {
+          variablesInFeature = Object.keys(parsedFeature.variablesSchema);
+        }
+
+        const hasVariables = lookForVariables.every((variable) =>
+          variablesInFeature.includes(variable),
+        );
 
         if (!hasVariables) {
           continue;

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -31,7 +31,67 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
       entity = (await datasource.readAttribute(key)) as T;
     }
 
-    // @TODO: filter
+    // filter
+    if (entityType === "feature") {
+      const parsedFeature = entity as ParsedFeature;
+
+      // --archived=true|false
+      if (parsedFeature.archived) {
+        const archivedStatus = options.archived === "false";
+
+        if (parsedFeature.archived !== archivedStatus) {
+          continue;
+        }
+      }
+
+      // --description=<pattern>
+      if (options.description) {
+        const description = parsedFeature.description || "";
+
+        const regex = new RegExp(options.description, "i");
+        if (!regex.test(description)) {
+          continue;
+        }
+      }
+
+      // @TODO --in=<environment>
+      // @TODO --keyPattern=<pattern>
+
+      // --tag=<tag>
+      if (options.tag) {
+        const tags = Array.isArray(options.tag) ? options.tag : [options.tag];
+        const hasTags = tags.every((tag) => parsedFeature.tags.includes(tag));
+
+        if (!hasTags) {
+          continue;
+        }
+      }
+
+      // @TODO --variable=<variableKey>
+      // @TODO --variableDescription=<pattern>
+      // @TODO --variation=<variationValue>
+      // @TODO --variationDescription=<pattern>
+      // @TODO --with-tests
+      // @TODO --with-variables
+      // @TODO --with-variations
+      // @TODO --without-tests
+      // @TODO --without-variables
+      // @TODO --without-variations
+    } else if (entityType === "segment") {
+      const segment = entity as Segment;
+
+      // @TODO --archived=true|false
+      // @TODO --description=<pattern>
+      // @TODO --keyPattern=<pattern>
+      // @TODO --with-tests
+      // @TODO --without-tests
+    } else if (entityType === "attribute") {
+      const attribute = entity as Attribute;
+
+      // @TODO --archived=true|false
+      // @TODO --description=<pattern>
+      // @TODO --keyPattern=<pattern>
+    }
 
     result.push({
       ...entity,

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -54,8 +54,37 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --in=<environment>
+      // --in=<environment>
+      if (parsedFeature.environments && parsedFeature.environments[options.in]) {
+        const enabledInEnvironment = parsedFeature.environments[options.in].rules.some((rule) => {
+          return rule.percentage > 0;
+        });
+
+        if (!enabledInEnvironment) {
+          continue;
+        }
+      }
+
       // @TODO --keyPattern=<pattern>
+      if (options.keyPattern) {
+        const regex = new RegExp(options.keyPattern, "i");
+        if (!regex.test(key)) {
+          continue;
+        }
+      }
+
+      // --notIn=<environment>
+      if (parsedFeature.environments && parsedFeature.environments[options.notIn]) {
+        const disabledInEnvironment = parsedFeature.environments[options.notIn].rules.every(
+          (rule) => {
+            return rule.percentage === 0;
+          },
+        );
+
+        if (!disabledInEnvironment) {
+          continue;
+        }
+      }
 
       // --tag=<tag>
       if (options.tag) {

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -1,0 +1,26 @@
+import { Dependencies } from "../dependencies";
+import { Plugin } from "../cli";
+
+export async function listProject(deps: Dependencies) {
+  const { rootDirectoryPath, projectConfig } = deps;
+
+  console.log("Listing project...");
+}
+
+export const listPlugin: Plugin = {
+  command: "list",
+  handler: async function ({ rootDirectoryPath, projectConfig, datasource, parsed }) {
+    await listProject({
+      rootDirectoryPath,
+      projectConfig,
+      datasource,
+      options: parsed,
+    });
+  },
+  examples: [
+    {
+      command: "list",
+      description: "list entities",
+    },
+  ],
+};

--- a/packages/core/src/list/index.ts
+++ b/packages/core/src/list/index.ts
@@ -207,7 +207,14 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --with-variations
+      // --with-variations
+      if (options.withVariations) {
+        const hasVariations = parsedFeature.variations;
+
+        if (!hasVariations) {
+          continue;
+        }
+      }
 
       // --without-tests
       if (options.withoutTests) {
@@ -227,7 +234,14 @@ async function listEntities<T>(deps: Dependencies, entityType): Promise<T[]> {
         }
       }
 
-      // @TODO --without-variations
+      // --without-variations
+      if (options.withoutVariations) {
+        const hasVariations = parsedFeature.variations;
+
+        if (hasVariations) {
+          continue;
+        }
+      }
     } else if (entityType === "segment") {
       const segment = entity as Segment;
 

--- a/packages/core/src/tester/index.ts
+++ b/packages/core/src/tester/index.ts
@@ -1,2 +1,3 @@
 export * from "./testProject";
 export * from "./testFeature";
+export * from "./matrix";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -167,6 +167,7 @@ export interface VariableSchema {
   key: VariableKey;
   type: VariableType;
   defaultValue: VariableValue;
+  description?: string;
 }
 
 export type FeatureKey = string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,6 +13,7 @@ export interface Attribute {
   key: AttributeKey;
   type: AttributeType;
   capture?: boolean;
+  description?: string; // only available in YAML files
 }
 
 export type Operator =
@@ -77,6 +78,7 @@ export interface Segment {
   archived?: boolean; // only available in YAML files
   key: SegmentKey;
   conditions: Condition | Condition[] | string; // string only when stringified for datafile
+  description?: string; // only available in YAML files
 }
 
 export type PlainGroupSegment = SegmentKey;
@@ -167,7 +169,7 @@ export interface VariableSchema {
   key: VariableKey;
   type: VariableType;
   defaultValue: VariableValue;
-  description?: string;
+  description?: string; // only available in YAML files
 }
 
 export type FeatureKey = string;


### PR DESCRIPTION
## What's done

Allow listing and filtering entities (features, segments, attributes) via CLI.

See diff for docs.

## TODOs

- [x] Think of `--json` output further, especially for multiple projects scenario
- [x] List tests, with optional `--apply-matrix`