### PR TITLE
fix: variable evaluation when variation is overridden from rule

### DIFF
--- a/examples/example-1/tests/features/qux.spec.yml
+++ b/examples/example-1/tests/features/qux.spec.yml
@@ -60,6 +60,8 @@ assertions:
       country: de
     expectedToBeEnabled: true
     expectedVariation: b
+    expectedVariables:
+      fooConfig: '{ "foo": "bar b" }' # stringified
 
   - at: 55 # (10 * 0.5) + 50
     environment: production
@@ -67,3 +69,5 @@ assertions:
       country: de
     expectedToBeEnabled: true
     expectedVariation: b
+    expectedVariables:
+      fooConfig: '{ "foo": "bar b" }' # stringified

--- a/packages/sdk/src/evaluate.ts
+++ b/packages/sdk/src/evaluate.ts
@@ -648,6 +648,8 @@ export function evaluate(options: EvaluateOptions): Evaluation {
 
       if (force && force.variation) {
         variationValue = force.variation;
+      } else if (matchedTraffic && matchedTraffic.variation) {
+        variationValue = matchedTraffic.variation;
       } else if (matchedAllocation && matchedAllocation.variation) {
         variationValue = matchedAllocation.variation;
       }


### PR DESCRIPTION
## Issue

- A feature with variables and variations, where
- each variation has its own set of variable overrides, and
- the variation itself is overridden at rule level, then
- variable evaluation was not taking the overridden variation from rule into account

## Solution

- Extra check added at variation evaluation level to also check for variation that is overridden at rule level
- `example-1` project's test specs updated accordingly