### PR TITLE
feat: cache JSON parsing in datafile lookups

### DIFF
--- a/examples/example-1/features/test.yml
+++ b/examples/example-1/features/test.yml
@@ -1,0 +1,38 @@
+description: Classic on/off switch
+tags:
+  - all
+
+bucketBy:
+  or:
+    - userId
+    - device
+
+environments:
+  staging:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 100
+  production:
+    expose: true
+    rules:
+      - key: "1"
+        segments:
+          or:
+            - countries/germany
+            - countries/netherlands
+            - countries/switzerland
+            - adult
+            - blackFridayWeekend
+            - desktop
+            - eu
+            - mobile
+            - qa
+            # - unknownDevice
+            - version_5.5
+            - version_gt5
+        percentage: 100
+
+      - key: "everyone"
+        segments: "*"
+        percentage: 0

--- a/packages/sdk/src/datafileReader.ts
+++ b/packages/sdk/src/datafileReader.ts
@@ -133,10 +133,10 @@ export class DatafileReader {
           typeof t.segments === "string" &&
           (t.segments.startsWith("{") || t.segments.startsWith("["))
         ) {
-          return JSON.parse(t.segments);
+          t.segments = JSON.parse(t.segments);
         }
 
-        return t.segments;
+        return t;
       });
 
       this.featureTrafficCache[featureKey] = feature.traffic;

--- a/packages/sdk/src/datafileReader.ts
+++ b/packages/sdk/src/datafileReader.ts
@@ -7,6 +7,7 @@ import {
   AttributeKey,
   SegmentKey,
   FeatureKey,
+  FeatureSegments,
 } from "@featurevisor/types";
 
 export function parseJsonConditionsIfStringified<T>(record: T, key: string): T {
@@ -29,9 +30,16 @@ export class DatafileReader {
   private segments: Record<SegmentKey, Segment>;
   private features: Record<FeatureKey, Feature>;
 
+  // fully parsed
+  private segmentsCache: Record<SegmentKey, Segment>;
+  private featureSegmentsCache: Record<string, FeatureSegments>;
+
   constructor(datafileJson: DatafileContentV1 | DatafileContentV2) {
     this.schemaVersion = datafileJson.schemaVersion;
     this.revision = datafileJson.revision;
+
+    this.segmentsCache = {};
+    this.featureSegmentsCache = {};
 
     if (this.schemaVersion === "2") {
       // v2
@@ -97,7 +105,13 @@ export class DatafileReader {
       return undefined;
     }
 
-    return parseJsonConditionsIfStringified(segment, "conditions");
+    if (this.segmentsCache[segmentKey]) {
+      return this.segmentsCache[segmentKey];
+    }
+
+    this.segmentsCache[segmentKey] = parseJsonConditionsIfStringified(segment, "conditions");
+
+    return this.segmentsCache[segmentKey];
   }
 
   getFeature(featureKey: FeatureKey): Feature | undefined {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -124,7 +124,7 @@ export type VariableValue =
   | undefined;
 
 export interface VariableOverrideSegments {
-  segments: GroupSegment | GroupSegment[];
+  segments: FeatureSegments;
 }
 
 export interface VariableOverrideConditions {
@@ -147,7 +147,7 @@ export interface VariableOverride {
   // one of the below must be present in YAML files
   // @TODO: try with above commented out TypeScript later
   conditions?: Condition | Condition[];
-  segments?: GroupSegment | GroupSegment[];
+  segments?: FeatureSegments;
 }
 
 export interface Variable {
@@ -178,7 +178,7 @@ export interface Force {
   // one of the below must be present in YAML
   // @TODO: make it better with TypeScript
   conditions?: Condition | Condition[];
-  segments?: GroupSegment | GroupSegment[];
+  segments?: FeatureSegments;
 
   enabled?: boolean;
   variation?: VariationValue;
@@ -213,9 +213,11 @@ export interface Allocation {
   range: Range; // @TODO: in future, turn it into `ranges`, so that Allocations with same variation do not repeat
 }
 
+export type FeatureSegments = GroupSegment | GroupSegment[] | "*";
+
 export interface Traffic {
   key: RuleKey;
-  segments: GroupSegment | GroupSegment[] | "*";
+  segments: FeatureSegments;
   percentage: Percentage;
 
   enabled?: boolean;
@@ -303,7 +305,7 @@ export type RuleKey = string;
 export interface Rule {
   key: RuleKey;
   description?: string; // only available in YAML
-  segments: GroupSegment | GroupSegment[];
+  segments: FeatureSegments;
   percentage: Weight;
 
   enabled?: boolean;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -74,10 +74,12 @@ export type Condition = PlainCondition | AndOrNotCondition;
 
 export type SegmentKey = string;
 
+export type Conditions = Condition | Condition[] | string; // string only when stringified for datafile
+
 export interface Segment {
   archived?: boolean; // only available in YAML files
   key: SegmentKey;
-  conditions: Condition | Condition[] | string; // string only when stringified for datafile
+  conditions: Conditions;
   description?: string; // only available in YAML files
 }
 


### PR DESCRIPTION
## Background

When building datafiles, Featurevisor stringifies segments in rules and their conditions by default: https://featurevisor.com/docs/configuration/#stringify

When JavaScript SDK evaluates a feature, it parses relevant stringified JSON just in time, every time.

## Issue

It's possible that this just in time JSON parsing for every evaluation (even if repeated using same SDK instance), can lead to additional time that we can avoid.

TODO: prove with real numbers.

## What's done

When a segment/condition stringified JSON is about to be parsed, it will now check if it has been parsed before and return the cached parsed value.

## Benchmarking

Via `example-1` project:

### Without optimization (main branch)

```
$ npx featurevisor benchmark --environment=production --feature=test --context='{"userId": "fh", "version": "5.0.1"}' -n=1000000

Running benchmark for feature "test"...

Building datafile containing all features for "production"...
Datafile build duration: 11ms
Datafile size: 9.20 kB

...SDK initialized

Against context: {"userId":"fh","version":"5.0.1"}
Evaluating flag 1000000 times...

Evaluated value : true
Total duration  : 2s 53ms
Average duration: 0.002053ms
```

### With optimization (this PR)

```
$ npx featurevisor benchmark --environment=production --feature=test --context='{"userId": "fh", "version": "5.0.1"}' -n=1000000

Running benchmark for feature "test"...

Building datafile containing all features for "production"...
Datafile build duration: 10ms
Datafile size: 9.20 kB

...SDK initialized

Against context: {"userId":"fh","version":"5.0.1"}
Evaluating flag 1000000 times...

Evaluated value : true
Total duration  : 2s 371ms
Average duration: 0.002371ms
```

### Results

No visible improvement in speed.

## TODOs

- [x] Implement caching in DatafileReader
- [ ] Make `DatafileReader` a bit more DRY
- [ ] Get rid of just in time parsing outside of DatafileReader
- [ ] Consider adding a new option for enabling caching for JSON parsing (defaulting to false for now may be)
- [x] Run benchmarks/tests with and without this optimization
- [x] Write PR description
- [ ] Merge if numbers are good
