### PR TITLE
chore: allow empty allocation for features without variations

### DIFF
--- a/packages/core/src/builder/traffic.ts
+++ b/packages/core/src/builder/traffic.ts
@@ -158,6 +158,8 @@ export function getTraffic(
       return true;
     });
 
+    // @TODO: in v2, remove "allocation" property if an empty array
+
     result.push(traffic);
   });
 

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -8,6 +8,10 @@ export function getMatchedAllocation(
   traffic: Traffic,
   bucketValue: number,
 ): Allocation | undefined {
+  if (!traffic.allocation) {
+    return undefined;
+  }
+
   for (const allocation of traffic.allocation) {
     const [start, end] = allocation.range;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -224,7 +224,7 @@ export interface Traffic {
     [key: string]: VariableValue;
   };
 
-  allocation: Allocation[];
+  allocation: Allocation[]; // @TODO: in v2, make it optional
 }
 
 export type PlainBucketBy = AttributeKey;
@@ -365,7 +365,7 @@ export interface ExistingFeature {
     // @TODO: use Exclude with Traffic?
     key: RuleKey;
     percentage: Percentage;
-    allocation: Allocation[];
+    allocation: Allocation[]; // @TODO: in v2, make it optional
   }[];
   ranges?: Range[]; // if in a Group (mutex), these are the available slot ranges
 }


### PR DESCRIPTION
## Background

- `feature.traffic[].allocation` is used for allocating variations (`Traffic.allocation` type)
- When the feature has no variations, it will always be an empty array in datafiles
- This causes unnecessary additional lines in datafile for simple features with no variations, that we can avoid

## What's done

In v2, we can remove this property if an empty array, resulting in smaller datafiles. See #326.

To avoid any breaking changes now, we are making 1.x SDK support it when `Traffic.allocation` is not present.

This will make migrating from latest 1.x to 2.0 later with ease.