### PR TITLE
feat: allow creating SDK instance without any options

### DIFF
--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -439,6 +439,6 @@ export class FeaturevisorInstance {
   }
 }
 
-export function createInstance(options: InstanceOptions): FeaturevisorInstance {
+export function createInstance(options: InstanceOptions = {}): FeaturevisorInstance {
   return new FeaturevisorInstance(options);
 }


### PR DESCRIPTION
## Background

In Featurevisor v2.0, all the options in `createInstance(options)` have become optional: 

- blog post: https://featurevisor.com/blog/v2-release/
- migration guide: https://featurevisor.com/docs/migrations/v2/

If nobody wanted to pass any additional options, they still had to pass an empty object:

```js
import { createInstance } from "@featurevisor/sdk";

const f = createInstance({});
```

## What's done

Now, the function can be called without passing any argument at all:

```js
const f = createInstance();
```