### PR TITLE
fix: namespaced feature environment links in status site

### DIFF
--- a/packages/site/src/components/ShowFeature.tsx
+++ b/packages/site/src/components/ShowFeature.tsx
@@ -192,7 +192,7 @@ export function DisplayFeatureForce() {
   const environmentTabs = environmentKeys.map((environmentKey) => {
     return {
       title: environmentKey,
-      to: `/features/${feature.key}/force/${environmentKey}`,
+      to: `/features/${encodeURIComponent(feature.key)}/force/${environmentKey}`,
     };
   });
 
@@ -315,7 +315,7 @@ export function DisplayFeatureRules() {
   const environmentTabs = environmentKeys.map((environmentKey) => {
     return {
       title: environmentKey,
-      to: `/features/${feature.key}/rules/${environmentKey}`,
+      to: `/features/${encodeURIComponent(feature.key)}/rules/${environmentKey}`,
     };
   });
 


### PR DESCRIPTION
## What's done

Fixes links to environment tabs/pills in individual feature view: https://featurevisor.com/docs/site/