### PR TITLE
feat: version in datafile

### DIFF
--- a/packages/core/src/builder/buildDatafile.ts
+++ b/packages/core/src/builder/buildDatafile.ts
@@ -89,6 +89,7 @@ export type BuildTags = BuildOrTags | BuildAndTags | string[];
 export interface BuildOptions {
   schemaVersion: string;
   revision: string;
+  featurevisorVersion?: string;
   revisionFromHash?: boolean;
   environment: string | false;
   tag?: string;
@@ -582,6 +583,7 @@ export async function buildDatafile(
   // schema v2
   const datafileContentV2: DatafileContent = {
     schemaVersion: "2",
+    featurevisorVersion: options.featurevisorVersion,
     revision: options.revision,
     segments: {},
     features: {},

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -28,6 +28,16 @@ export interface BuildCLIOptions {
   scope?: string; // scope name only
 }
 
+function getFeaturevisorVersion(): string {
+  try {
+    const cliPackage = require(require.resolve("@featurevisor/cli/package.json"));
+
+    return cliPackage.version;
+  } catch (error) {
+    return "unknown";
+  }
+}
+
 async function buildForEnvironment({
   projectConfig,
   datasource,
@@ -48,6 +58,7 @@ async function buildForEnvironment({
   console.log(`\nBuilding datafiles for environment: ${environment}`);
 
   const existingState = await datasource.readState(environment);
+  const featurevisorVersion = getFeaturevisorVersion();
 
   // by tag
   for (const tag of tags) {
@@ -63,6 +74,7 @@ async function buildForEnvironment({
         environment: environment,
         tag: tag,
         inflate: cliOptions.inflate,
+        featurevisorVersion,
       },
       existingState,
     );
@@ -91,6 +103,7 @@ async function buildForEnvironment({
           tag: scope.tag,
           tags: scope.tags,
           inflate: cliOptions.inflate,
+          featurevisorVersion,
         },
         existingState,
       );

--- a/packages/core/src/builder/buildProject.ts
+++ b/packages/core/src/builder/buildProject.ts
@@ -33,6 +33,7 @@ function getFeaturevisorVersion(): string {
     const cliPackage = require(require.resolve("@featurevisor/cli/package.json"));
 
     return cliPackage.version;
+    // eslint-disable-next-line
   } catch (error) {
     return "unknown";
   }

--- a/packages/types/src/datafile.d.ts
+++ b/packages/types/src/datafile.d.ts
@@ -85,6 +85,7 @@ export interface DatafileContentV1 {
 export interface DatafileContent {
   schemaVersion: string;
   revision: string;
+  featurevisorVersion?: string; // @TODO: make it required in v3
   segments: {
     [key: SegmentKey]: Segment;
   };


### PR DESCRIPTION
## What's done

- Show `@featurevisor/cli` version in generated datafiles

## Why?

- This helps SDKs in runtime know which version of CLI was used to generate the datafiles
- Making it easier for introducing new functionalities incrementally, without having to cause any breaking changes
- By the time v3 arrives (currently in v2), the `schemaVersion` can move to `3` from `2` and the SDKs can stop worrying about backwards compatibility

