### PR TITLE
fix(core): properly annotate type only imports

### DIFF
--- a/packages/core/src/generate-code/typescript.ts
+++ b/packages/core/src/generate-code/typescript.ts
@@ -926,8 +926,8 @@ import {
   useVariable as useVariableOriginal,
 } from "@featurevisor/react";
 
-import { FeatureKey, Variation, VariableKey, VariableType } from "./features";
-import { Context } from "./context";
+import type { FeatureKey, Variation, VariableKey, VariableType } from "./features";
+import type { Context } from "./context";
 
 export function useFlag(featureKey: FeatureKey, context: Context = {}): boolean {
   return useFlagOriginal(featureKey, context);


### PR DESCRIPTION
Updated imports to use type-only imports for TypeScript.

I have to manually adjust the generated `functions.ts` each time i generate because my linting rules are strict. 

<img width="1236" height="181" alt="image" src="https://github.com/user-attachments/assets/9bf299b4-0d02-42b8-b0e8-aa6b91124812" />
